### PR TITLE
Fix a warning in the CLA build process.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,15 +2,17 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
-    types: [opened,closed,synchronize]
+#  pull_request_target:
+#    types: [opened,closed,synchronize]
+  pull_request:
+    branches: [ main, release* ]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-20.04
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') #|| github.event_name == 'pull_request_target'
         uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+  pull_request:
+    branches: [ main, release* ]
 
 jobs:
   CLAssistant:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') #|| github.event_name == 'pull_request_target'
+        #if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') #|| github.event_name == 'pull_request_target'
         uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,17 +2,15 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
-#  pull_request_target:
-#    types: [opened,closed,synchronize]
-  pull_request:
-    branches: [ main, release* ]
+  pull_request_target:
+    types: [opened,closed,synchronize]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-20.04
     steps:
       - name: "CLA Assistant"
-        #if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') #|| github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.1.1-beta
+        uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'CLA/signatures/v1.0/cla.json'
-          path-to-cla-document: 'https://github.com/corgibytes/freshli-cli/blob/main/CLA/CLA-v1.0.md'
+          path-to-document: 'https://github.com/corgibytes/freshli-cli/blob/main/CLA/CLA-v1.0.md'
           branch: 'main'
           allowlist: dependabot[bot]
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,8 +4,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
-  pull_request:
-    branches: [ main, release* ]
 
 jobs:
   CLAssistant:


### PR DESCRIPTION
Fixes #35.

By default the CLA build process triggers on [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) which means it will use the old CLA workflow in `release-0.4` branch which has not been fixed and will still raise an error.  To test the updated CLA file I temporarily changed the workflow to trigger on [pull_request](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request).  You can see the results of my tests [here](https://github.com/corgibytes/freshli-cli/runs/3069204651?check_suite_focus=true).