### PR TITLE
Fixes #33, removes warning for GitReleaseManager on Add Asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,15 +161,15 @@ jobs:
           path: ${{ env.NUGET_PACKAGE_PATH }}
 
       - name: "[Post Publish] - Add Assets to Release Draft"
-        if: ${{ github.event_name == 'push' }}
-        uses: gittools/actions/gitreleasemanager/addasset@v0.9.9
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          owner: 'corgibytes'
-          repository: 'freshli-cli'
-          milestone: 'v${{ steps.gitversion.outputs.majorMinorPatch }}'
-          tagName: 'v${{ steps.gitversion.outputs.majorMinorPatch }}'
-          assets: '${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-win-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-linux-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-osx-x64.zip,${{ env.NUGET_PACKAGE_PATH }}'
+        if: github.event_name == 'push'
+        run: |
+          dotnet-gitreleasemanager addasset \
+            --owner corgibytes \
+            --repository freshli-cli \
+            --token ${{ secrets.GITHUB_TOKEN }} \
+            --targetDirectory /home/runner/work/freshli-cli/freshli-cli \
+            --tagName 'v${{ steps.gitversion.outputs.majorMinorPatch }}' \
+            --assets ${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-win-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-linux-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-osx-x64.zip,${{ env.NUGET_PACKAGE_PATH }}
 
       # Push all versions to GitHub packages.  This includes alpha version, in the main branch, and beta
       # versions in the release branch.


### PR DESCRIPTION
This PR removes the warning from #33 from the .NET Core CI process, basically converting from using the provided action to calling the `git-releasemanager` command directly.

This PR took some work, as upgrading to later versions of the GitReleaseManager tool proves to have some issues, and depending how deep we'd like to take this, may warrant opening issues with the tool on their repository.
The following draft PR shows the work process that occurs with different configurations, which yields the following:

* If we upgrade to GitReleaseManager 0.12, it still requires tagName via [this documentation](https://gittools.github.io/GitReleaseManager/docs/commands/add-assets) and if tagName is provided, we'll receive a ObjectReferenceError that I believe relates to how the assets are passed in:

![image](https://user-images.githubusercontent.com/564106/129813730-cddf5855-0341-41b1-8fdb-962ee7681e93.png)

* Using the action provided in `gittools` (if sticking with GitReleaseManager 0.11) will indicate that `tagName` is required if tagName is omitted:

![image](https://user-images.githubusercontent.com/564106/129813794-5f2bd662-13b8-4003-8c49-1e7a3386ceab.png)

Reference:
https://github.com/corgibytes/freshli-cli/pull/40