### PR TITLE
Feature upgrade to Freshli-Lib v0.4.0

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/OutputFormatterTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/OutputFormatterTest.cs
@@ -9,37 +9,37 @@ namespace Corgibytes.Freshli.Cli.Test
 {
     public class OutputFormatterTest
     {
-        private static IList<(DateTime Date, double Value, bool UpgradeAvailable, bool Skipped)> DatesAndValues
+        private static IEnumerable<(DateTime Date, double Value, bool UpgradeAvailable, bool Skipped)> DatesAndValues
         {
             get
             {
-                return new List<(
-        DateTime Date, double Value, bool UpgradeAvailable, bool Skipped)>
-      {
-        (new DateTime(2010, 01, 01), 1.1010, false, false),
-        (new DateTime(2010, 02, 01), 2.2020, false, false),
-        (new DateTime(2010, 03, 01), 3.3030, false, false),
-        (new DateTime(2010, 04, 01), 4.4040, false, false),
-        (new DateTime(2010, 05, 01), 5.5050, false, false),
-        (new DateTime(2010, 06, 01), 6.6060, false, false),
-        (new DateTime(2010, 07, 01), 7.7070, false, false),
-        (new DateTime(2010, 08, 01), 8.8080, false, false),
-        (new DateTime(2010, 09, 01), 9.9090, false, false),
-        (new DateTime(2010, 10, 01), 10.0101, false, false),
-        (new DateTime(2010, 11, 01), 11.1111, true, false),
-        (new DateTime(2010, 12, 01), 12.2121, true, false),
-        (new DateTime(2011, 01, 01), 13.3333, false, true)
-      };
+                return new List<(DateTime Date, double Value, bool UpgradeAvailable, bool Skipped)>
+                {
+                    (new DateTime(2010, 01, 01), 1.1010, false, false),
+                    (new DateTime(2010, 02, 01), 2.2020, false, false),
+                    (new DateTime(2010, 03, 01), 3.3030, false, false),
+                    (new DateTime(2010, 04, 01), 4.4040, false, false),
+                    (new DateTime(2010, 05, 01), 5.5050, false, false),
+                    (new DateTime(2010, 06, 01), 6.6060, false, false),
+                    (new DateTime(2010, 07, 01), 7.7070, false, false),
+                    (new DateTime(2010, 08, 01), 8.8080, false, false),
+                    (new DateTime(2010, 09, 01), 9.9090, false, false),
+                    (new DateTime(2010, 10, 01), 10.0101, false, false),
+                    (new DateTime(2010, 11, 01), 11.1111, true, false),
+                    (new DateTime(2010, 12, 01), 12.2121, true, false),
+                    (new DateTime(2011, 01, 01), 13.3333, false, true)
+                };
             }
         }
 
-        private static IList<MetricsResult> CreateResults()
+        private static IList<ScanResult> CreateResults()
         {
-            IList<MetricsResult> results = new List<MetricsResult>();
+            List<MetricsResult> metricResults = new();
             foreach (var dateAndValue in DatesAndValues)
             {
-                var result = new LibYearResult();
-                result.Add(new LibYearPackageResult
+                var result = new LibYearResult
+                {
+                    new LibYearPackageResult
                     (
                         "test_package",
                         "1.0",
@@ -50,11 +50,14 @@ namespace Corgibytes.Freshli.Cli.Test
                         dateAndValue.UpgradeAvailable,
                         dateAndValue.Skipped
                     )
-                );
-                results.Add(new MetricsResult(dateAndValue.Date, "N-A", result));
+                };
+                metricResults.Add(new MetricsResult(dateAndValue.Date, "N-A", result));
             }
 
-            return results;
+            IList<ScanResult> scanResults = new List<ScanResult>();
+            scanResults.Add(new ScanResult("SomeFileName.foo", metricResults));
+
+            return scanResults;
         }
 
         private static string EnglishHeader = "Date (yyyy-MM-dd)\tLibYear\tUpgradesAvailable\tSkipped";
@@ -63,21 +66,24 @@ namespace Corgibytes.Freshli.Cli.Test
         private static string ExpectedDatesAndValues(string header)
         {
             StringWriter expected = new StringWriter();
-                expected.WriteLine(header);
-                expected.WriteLine("2010-01-01\t1.1010\t0\t0");
-                expected.WriteLine("2010-02-01\t2.2020\t0\t0");
-                expected.WriteLine("2010-03-01\t3.3030\t0\t0");
-                expected.WriteLine("2010-04-01\t4.4040\t0\t0");
-                expected.WriteLine("2010-05-01\t5.5050\t0\t0");
-                expected.WriteLine("2010-06-01\t6.6060\t0\t0");
-                expected.WriteLine("2010-07-01\t7.7070\t0\t0");
-                expected.WriteLine("2010-08-01\t8.8080\t0\t0");
-                expected.WriteLine("2010-09-01\t9.9090\t0\t0");
-                expected.WriteLine("2010-10-01\t10.0101\t0\t0");
-                expected.WriteLine("2010-11-01\t11.1111\t1\t0");
-                expected.WriteLine("2010-12-01\t12.2121\t1\t0");
-                expected.WriteLine("2011-01-01\t0.0000\t0\t1");
-                return expected.ToString();
+
+            expected.WriteLine("SomeFileName.foo");
+            expected.WriteLine(header);
+            expected.WriteLine("2010-01-01\t1.1010\t0\t0");
+            expected.WriteLine("2010-02-01\t2.2020\t0\t0");
+            expected.WriteLine("2010-03-01\t3.3030\t0\t0");
+            expected.WriteLine("2010-04-01\t4.4040\t0\t0");
+            expected.WriteLine("2010-05-01\t5.5050\t0\t0");
+            expected.WriteLine("2010-06-01\t6.6060\t0\t0");
+            expected.WriteLine("2010-07-01\t7.7070\t0\t0");
+            expected.WriteLine("2010-08-01\t8.8080\t0\t0");
+            expected.WriteLine("2010-09-01\t9.9090\t0\t0");
+            expected.WriteLine("2010-10-01\t10.0101\t0\t0");
+            expected.WriteLine("2010-11-01\t11.1111\t1\t0");
+            expected.WriteLine("2010-12-01\t12.2121\t1\t0");
+            expected.WriteLine("2011-01-01\t0.0000\t0\t1");
+
+            return expected.ToString();
         }
 
         private static void TestOutputFormatter(CultureInfo testedCulture, string expectedHeader)
@@ -95,7 +101,7 @@ namespace Corgibytes.Freshli.Cli.Test
         }
 
         [Fact]
-        public void EnglishUSLanguage()
+        public void EnglishUnitedStatesLanguage()
         {
             TestOutputFormatter(CultureInfo.GetCultureInfo("en-US"), EnglishHeader);
         }

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -19,7 +19,7 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="">
       <Link>LICENSE</Link>
     </None>
-    <PackageReference Include="Corgibytes.Freshli.Lib" Version="0.4.0-alpha0208" />
+    <PackageReference Include="Corgibytes.Freshli.Lib" Version="0.4.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\CliOutput.resx">

--- a/Corgibytes.Freshli.Cli/OutputFormatter.cs
+++ b/Corgibytes.Freshli.Cli/OutputFormatter.cs
@@ -17,23 +17,27 @@ namespace Corgibytes.Freshli.Cli
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture; //format for dates and numbers to use invariant
         }
 
-        public void Write(IList<MetricsResult> results)
+        public void Write(IEnumerable<ScanResult> results)
         {
-            _writer.WriteLine(
-              CliOutput.Output_Date + Separator +
-              CliOutput.Output_LibYear + Separator +
-              CliOutput.Output_UpgradesAvailable + Separator +
-              CliOutput.Output_Skipped
-            );
-
-            foreach (var resultSet in results)
+            foreach ((string filename, List<MetricsResult> metricsResults) in results)
             {
+                _writer.WriteLine(filename);
                 _writer.WriteLine(
-                  $"{resultSet.Date:yyyy-MM-dd}" + Separator +
-                  $"{resultSet.LibYear.Total:F4}" + Separator +
-                  $"{resultSet.LibYear.UpgradesAvailable}" + Separator +
-                  $"{resultSet.LibYear.Skipped}"
+                    CliOutput.Output_Date + Separator +
+                    CliOutput.Output_LibYear + Separator +
+                    CliOutput.Output_UpgradesAvailable + Separator +
+                    CliOutput.Output_Skipped
                 );
+
+                foreach (var metricResult in metricsResults)
+                {
+                    _writer.WriteLine(
+                        $"{metricResult.Date:yyyy-MM-dd}" + Separator +
+                        $"{metricResult.LibYear.Total:F4}" + Separator +
+                        $"{metricResult.LibYear.UpgradesAvailable}" + Separator +
+                        $"{metricResult.LibYear.Skipped}"
+                    );
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The above repo is one we use for testing Freshli.  When run you should get outpu
 
 ```
 > Corgibytes.Freshli.Cli.exe https://github.com/corgibytes/freshli-fixture-ruby-nokotest
+Gemfile.lock
 Date (yyyy-MM-dd)       LibYear UpgradesAvailable       Skipped
 2017-01-01              0.0000  0                       0
 2017-02-01              0.0219  1                       0
@@ -117,13 +118,14 @@ Please let us know what other dependency managers and/or manifest files you woul
 Freshli check your projects dependencies at on month intervals and returns a table with the following that looks like:
 
 ```
+Gemfile.lock
 Date (yyyy-MM-dd)       LibYear UpgradesAvailable       Skipped
 2017-01-01              0.0000  0                       0
 2017-02-01              0.0219  1                       0
 ...
 ```
 
-The values in the table are:
+First is the name of the manifest file being parsed followed by the historical values for that manifest file:
 
 - Date: The date the check was done.
 - Libyear: The total [libyear](https://libyear.com/) of all the dependencies.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Update the CLI to use Freshli-Lib v0.4.0 which support multiple manifests.