### PR TITLE
Removes installation of .NET Core 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,6 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      # .NET Core 3 is required for GitReleaseManager.
-      - name: "[Setup] - .NET Core 3 (GitReleaseManager)"
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.0.x
-
       - name: "[Setup] - Install GitVersion"
         uses: gittools/actions/gitversion/setup@v0.9.13
         with:


### PR DESCRIPTION
GitReleaseManager now works with .NET 6, so we don't need to install this older version anymore. This should silence a warning that we're getting in the build output about .NET 3.0 not having support anymore.

Closes #72.