### PR TITLE
Rename executable from `Corgibytes.Freshli.Cli` to `freshli`

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -15,7 +15,10 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>freshli</ToolCommandName>
     <LangVersion>latestmajor</LangVersion>
-  </PropertyGroup>     
+    <PackageId>Corgibytes.Freshli.Cli</PackageId>
+    <Company>Corgibytes</Company>
+    <AssemblyName>freshli</AssemblyName>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="">
       <Link>LICENSE</Link>

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -7,4 +7,8 @@ Feature: Cache
         And we can open a SQLite connection to "~/.freshli/freshli.db"
 
     Scenario: Prepare with overridden cache-dir
+        Given a directory named "~/somewhere_else" does not exist
         When I run `freshli cache prepare --cache-dir somewhere_else`
+        Then the directory named "~/somewhere_else" should exist
+        And a file named "~/somewhere_else/freshli.db" should exist
+        And we can open a SQLite connection to "~/somewhere_else/freshli.db"

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -1,13 +1,10 @@
 Feature: Cache
     Scenario: Prepare
         Given a directory named "~/.freshli" does not exist
-        When I run `Corgibytes.Freshli.Cli cache prepare`
+        When I run `freshli cache prepare`
         Then the directory named "~/.freshli" should exist
         And a file named "~/.freshli/freshli.db" should exist
         And we can open a SQLite connection to "~/.freshli/freshli.db"
 
     Scenario: Prepare with overridden cache-dir
-        Given a directory named "somewhere_else" does not exist
-        When I run `Corgibytes.Freshli.Cli cache prepare --cache-dir somewhere_else`
-        Then the directory named "somewhere_else" should exist
-        And a file named "somewhere_else/freshli.db" should exist
+        When I run `freshli cache prepare --cache-dir somewhere_else`

--- a/features/help.feature
+++ b/features/help.feature
@@ -1,10 +1,10 @@
 Feature: Freshli.Cli
     Scenario: Help option
-        When I run `Corgibytes.Freshli.Cli --help`
+        When I run `freshli --help`
         Then the output should contain:
         """
         Usage:
-          Corgibytes.Freshli.Cli [command] [options]
+          freshli [command] [options]
         """
         And the output should contain:
         """


### PR DESCRIPTION
Renames the binary that's produced when the project is built.

Closes #65.