### PR TITLE
Bumps System.CommandLine dependencies to latest versions

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Corgibytes.Freshli.Cli.Test.csproj
+++ b/Corgibytes.Freshli.Cli.Test/Corgibytes.Freshli.Cli.Test.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageReference Include="xunit" Version="2.4.2-pre.12" />
     <PackageReference Include="Xunit.DependencyInjection" Version="8.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="NamedServices.Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta1" />
     <PackageReference Include="ServiceStack.Text" Version="6.1.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" /> 
   </ItemGroup>

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta1" />
     <PackageReference Include="ServiceStack.Text" Version="6.1.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" /> 
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The dependabot created pull requests to update these dependencies didn't work because one of the libraries depends on the other. I suspect this might be an issue again the next time these need to be upgraded.

Replaces #89.
Replaces #90.