### PR TITLE
Disable the similar code check in CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,5 +9,4 @@ checks:
     config:
       threshold: 45
   similar-code:
-    config:
-      threshold: 100
+    enabled: false


### PR DESCRIPTION
We've upped the threshold for this check a few times. Each time it was
for boiler plate code in tests. The check itself is useful but only if
we could exclude the tests for this particular check which we can't
(yet?). Until that time, since it's losing value, disable the check
entirely.

https://docs.codeclimate.com/docs/advanced-configuration#exclude-patterns
> Exclusions can only be made at the global level (excluding code from all analysis) or at the plugin-level (excluding code only from specific third-party plugins). Currently, exclusions cannot be made for individual maintainability checks.