### PR TITLE
Abstract External Process Calls

### DIFF
--- a/Corgibytes.Freshli.Cli/Functionality/Git/GitSource.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/GitSource.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using System.Text;
-using CliWrap;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Repositories;
 using Corgibytes.Freshli.Cli.Resources;
@@ -105,103 +104,56 @@ public class GitSource
 
     private void Clone(string gitPath)
     {
-        var stdErrBuffer = new StringBuilder();
-        var command = CliWrap.Cli.Wrap(gitPath).WithArguments(
-                args => args
-                    .Add("clone")
-                    .Add(Url)
-                    .Add('.')
-            )
-            .WithValidation(CommandResultValidation.None)
-            .WithWorkingDirectory(Directory.FullName)
-            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
-
-        using var task = command.ExecuteAsync().Task;
-        task.Wait();
-
-        if (task.Result.ExitCode != 0)
+        try
+        {
+            Invoke.Command(gitPath, $"clone {Url} .");
+        }
+        catch (IOException e)
         {
             Delete();
-            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{stdErrBuffer}");
+            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{e.Message}");
         }
     }
 
     private void Checkout(string gitPath)
     {
-        var stdErrBuffer = new StringBuilder();
-        var command = CliWrap.Cli.Wrap(gitPath).WithArguments(
-                args => args
-                    .Add("checkout")
-                    .Add(Branch ?? "")
-            )
-            .WithWorkingDirectory(Directory.FullName)
-            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
-
-        using var task = command.ExecuteAsync().Task;
-        task.Wait();
-
-        if (task.Result.ExitCode != 0)
+        try
+        {
+            Invoke.Command(gitPath, $"checkout {Branch ?? ""}");
+        }
+        catch (IOException e)
         {
             Delete();
-            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{stdErrBuffer}");
+            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{e.Message}");
         }
     }
 
     private void Pull(string gitPath)
     {
-        var stdOutBuffer = new StringBuilder();
         var branch = Branch;
         if (Branch == null)
         {
             branch = FetchCurrentBranch(gitPath);
         }
 
-        var stdErrBuffer = new StringBuilder();
-        var command = CliWrap.Cli.Wrap(gitPath).WithArguments(
-                args => args
-                    .Add("pull")
-                    .Add("origin")
-                    .Add(branch ?? "")
-            )
-            .WithWorkingDirectory(Directory.FullName)
-            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
-            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
+        string? commandOutput = null;
 
-        using var task = command.ExecuteAsync().Task;
-        task.Wait();
-
-        var commandOutput = stdOutBuffer.ToString().Replace("\n", " ");
-
-        if (task.Result.ExitCode != 0 && commandOutput.Equals("Already up to date.") == false)
+        try
         {
-            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{stdErrBuffer}");
+            commandOutput = Invoke.Command(gitPath, $"pull origin {branch ?? ""}")
+                .Replace("\n", " ");
+        }
+        catch (IOException e)
+        {
+            if (commandOutput == "Already up to date.")
+            {
+                throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{e.Message}");
+            }
         }
     }
 
-    private string FetchCurrentBranch(string gitPath)
-    {
-        var stdErrBuffer = new StringBuilder();
-        var stdOutBuffer = new StringBuilder();
-
-        var command = CliWrap.Cli.Wrap(gitPath).WithArguments(
-                args => args
-                    .Add("branch")
-                    .Add("--show-current")
-            )
-            .WithWorkingDirectory(Directory.FullName)
-            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
-            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
-
-        using var task = command.ExecuteAsync().Task;
-        task.Wait();
-
-        if (task.Result.ExitCode != 0)
-        {
-            throw new GitException($"{CliOutput.Exception_Git_EncounteredError}\n{stdErrBuffer}");
-        }
-
-        return stdOutBuffer.ToString().Replace("\n", "");
-    }
+    private static string FetchCurrentBranch(string gitPath) =>
+        Invoke.Command(gitPath, "branch --show-current").Replace("\n", "");
 
     public void CloneOrPull(string gitPath)
     {

--- a/Corgibytes.Freshli.Cli/Functionality/Git/GitSource.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/GitSource.cs
@@ -106,7 +106,7 @@ public class GitSource
     {
         try
         {
-            Invoke.Command(gitPath, $"clone {Url} .");
+            Invoke.Command(gitPath, $"clone {Url} .", Directory.FullName);
         }
         catch (IOException e)
         {
@@ -119,7 +119,7 @@ public class GitSource
     {
         try
         {
-            Invoke.Command(gitPath, $"checkout {Branch ?? ""}");
+            Invoke.Command(gitPath, $"checkout {Branch ?? ""}", Directory.FullName);
         }
         catch (IOException e)
         {
@@ -140,7 +140,7 @@ public class GitSource
 
         try
         {
-            commandOutput = Invoke.Command(gitPath, $"pull origin {branch ?? ""}")
+            commandOutput = Invoke.Command(gitPath, $"pull origin {branch ?? ""}", Directory.FullName)
                 .Replace("\n", " ");
         }
         catch (IOException e)
@@ -152,8 +152,10 @@ public class GitSource
         }
     }
 
-    private static string FetchCurrentBranch(string gitPath) =>
-        Invoke.Command(gitPath, "branch --show-current").Replace("\n", "");
+    private string FetchCurrentBranch(string gitPath)
+    {
+        return Invoke.Command(gitPath, "branch --show-current", Directory.FullName).Replace("\n", "");
+    }
 
     public void CloneOrPull(string gitPath)
     {

--- a/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Reflection;
+using System.Text;
+using CliWrap;
+
+namespace Corgibytes.Freshli.Cli.Functionality;
+
+public static class Invoke
+{
+    public static string Command(string executable, string arguments)
+    {
+        var stdOutBuffer = new StringBuilder();
+        var stdErrBuffer = new StringBuilder();
+
+        var command = CliWrap.Cli.Wrap(executable).WithArguments(
+                args => args
+                    .Add(arguments.Split())
+            )
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
+
+        using var task = command.ExecuteAsync().Task;
+        task.Wait();
+
+        if (task.Result.ExitCode != 0)
+        {
+            throw new IOException(stdErrBuffer.ToString());
+        }
+
+        return stdOutBuffer.ToString();
+    }
+
+    // This will be needed in later work, but is being defined now, so we'll disable the warning about being unused.
+    // ReSharper disable once UnusedMember.Global
+    public static string Freshli(string arguments)
+    {
+        var executionLocation = new FileInfo(
+            Assembly.GetExecutingAssembly().Location
+        ).Directory!; // null is forgivable here, because if we get null, there are far weirder problems afoot
+        var executable = new FileInfo(executionLocation.FullName + "/freshli");
+
+        try
+        {
+            return Command(executable.FullName, arguments);
+        }
+        catch (IOException e)
+        {
+            throw new IOException(
+                $"Invoking 'freshli {arguments}' failed with the following output:\n{e.Message}"
+            );
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Reflection;
 using System.Text;
 using CliWrap;
 

--- a/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
@@ -30,25 +30,4 @@ public static class Invoke
 
         return stdOutBuffer.ToString();
     }
-
-    // This will be needed in later work, but is being defined now, so we'll disable the warning about being unused.
-    // ReSharper disable once UnusedMember.Global
-    public static string Freshli(string arguments)
-    {
-        var executionLocation = new FileInfo(
-            Assembly.GetExecutingAssembly().Location
-        ).Directory!; // null is forgivable here, because if we get null, there are far weirder problems afoot
-        var executable = new FileInfo(executionLocation.FullName + "/freshli");
-
-        try
-        {
-            return Command(executable.FullName, arguments);
-        }
-        catch (IOException e)
-        {
-            throw new IOException(
-                $"Invoking 'freshli {arguments}' failed with the following output:\n{e.Message}"
-            );
-        }
-    }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Invoke.cs
@@ -7,7 +7,7 @@ namespace Corgibytes.Freshli.Cli.Functionality;
 
 public static class Invoke
 {
-    public static string Command(string executable, string arguments)
+    public static string Command(string executable, string arguments, string workingDirectory)
     {
         var stdOutBuffer = new StringBuilder();
         var stdErrBuffer = new StringBuilder();
@@ -16,6 +16,7 @@ public static class Invoke
                 args => args
                     .Add(arguments.Split())
             )
+            .WithWorkingDirectory(workingDirectory)
             .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuffer))
             .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErrBuffer));
 


### PR DESCRIPTION
Adds the Invoke.Command() and Invoke.Freshli() methods for
executing external processes with CliWrap. This eliminates
boilerplate from the rest of the project.

Changes all prior direct invocations of processes with CliWrap
to use Invoke.Command() instead.

Invoke.Freshli() method will be needed in upcoming work. This just
defines it, since it was written as part of a now-abandoned task
and worth retaining.

---

I credited Dona on this task because she helped write the method
that I further developed here into Invoke.Freshli() and Invoke.Command().