### PR TITLE
Explicitly set the culture to the invariant culture

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -19,6 +19,7 @@
     <Company>Corgibytes</Company>
     <AssemblyName>freshli</AssemblyName>
     <Nullable>enable</Nullable>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="">


### PR DESCRIPTION
Fixes #123 

https://stackoverflow.com/questions/12729922/how-to-set-cultureinfo-invariantculture-default
https://docs.microsoft.com/EN-US/dotnet/core/runtime-config/globalization

There are a few ways that invariant culture can be set as default yet, from what I could find, none of those were being used. 

### Before
![Screenshot from 2022-08-05 15-10-37](https://user-images.githubusercontent.com/7047894/183085180-a96f255d-d604-4709-b771-d55c6a9b106b.png)

### Beafter
![Screenshot from 2022-08-05 15-11-00](https://user-images.githubusercontent.com/7047894/183085195-ad2827ce-6a79-4701-963e-0b654f6aaf5e.png)

