### PR TITLE
Port git clone functionality to CQRS-lite architecture

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
@@ -1,0 +1,61 @@
+using Corgibytes.Freshli.Cli.DataModel;
+using Corgibytes.Freshli.Cli.Exceptions;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.Git;
+using Moq;
+using Xunit;
+
+namespace Corgibytes.Freshli.Cli.Test.Functionality.Git;
+
+[UnitTest]
+public class CloneGitRepositoryActivityTest
+{
+    private readonly string _branch;
+
+    private readonly string _cacheDir;
+    private readonly Mock<IApplicationEventEngine> _eventEngine = new();
+    private readonly string _gitPath;
+    private readonly Mock<ICachedGitSourceRepository> _gitSourceRepository = new();
+    private readonly string _localPath;
+    private readonly string _repositoryId;
+    private readonly string _url;
+
+    public CloneGitRepositoryActivityTest()
+    {
+        _cacheDir = "example";
+        _url = "http://git.exaple.com";
+        _branch = "main";
+
+        _gitPath = "git";
+        _repositoryId = "test";
+        _localPath = "test";
+    }
+
+    [Fact]
+    public void HandlerFiresGitRepositoryClonedEventWhenInvokedFromCli()
+    {
+        _gitSourceRepository.Setup(mock => mock.CloneOrPull(_url, _branch, _cacheDir, _gitPath))
+            .Returns(new CachedGitSource(_repositoryId, _url, _branch, _localPath));
+
+        var activity = new CloneGitRepositoryActivity(_gitSourceRepository.Object, _url, _branch, _cacheDir, _gitPath);
+
+        activity.Handle(_eventEngine.Object);
+
+        _eventEngine.Verify(mock =>
+            mock.Fire(It.Is<GitRepositoryClonedEvent>(value => value.GitRepositoryId == _repositoryId)));
+    }
+
+    [Fact]
+    public void HandlerFiresCloneGitRepositoryFailedEventWhenCloneFailsAndInvokedFromCli()
+    {
+        _gitSourceRepository.Setup(mock => mock.CloneOrPull(_url, _branch, _cacheDir, _gitPath))
+            .Throws(new GitException("Git clone failed"));
+
+        var activity = new CloneGitRepositoryActivity(_gitSourceRepository.Object, _url, _branch, _cacheDir, _gitPath);
+
+        activity.Handle(_eventEngine.Object);
+
+        _eventEngine.Verify(mock =>
+            mock.Fire(It.Is<CloneGitRepositoryFailedEvent>(value => value.ErrorMessage == "Git clone failed")));
+    }
+}

--- a/Corgibytes.Freshli.Cli/CommandRunners/Git/GitCloneCommandRunner.cs
+++ b/Corgibytes.Freshli.Cli/CommandRunners/Git/GitCloneCommandRunner.cs
@@ -31,7 +31,6 @@ public class GitCloneCommandRunner : CommandRunner<GitCloneCommand, GitCloneComm
     {
         _activityEngine.Dispatch(new CloneGitRepositoryActivity(_gitSourceRepository,
             options.RepoUrl, options.Branch, options.CacheDir, options.GitPath));
-        //_activityEngine.Dispatch(new CloneGitRepositoryActivity(_analysisId));
 
         var exitCode = true.ToExitCode();
         _eventEngine.On<GitRepositoryClonedEvent>(clonedEvent =>

--- a/Corgibytes.Freshli.Cli/Functionality/Git/CachedGitSourceRepository.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/CachedGitSourceRepository.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Exceptions;
 using Corgibytes.Freshli.Cli.Resources;
+using Newtonsoft.Json;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Git;
 
@@ -14,7 +15,7 @@ public class CachedGitSourceRepository : ICachedGitSourceRepository
     public CachedGitSourceRepository(ICacheManager cacheManager) =>
         CacheManager = cacheManager;
 
-    private ICacheManager CacheManager { get; }
+    [JsonProperty] private ICacheManager CacheManager { get; }
 
     public CachedGitSource FindOneByHash(string hash, string cacheDir)
     {

--- a/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryActivity.cs
@@ -1,0 +1,38 @@
+using Corgibytes.Freshli.Cli.Exceptions;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Newtonsoft.Json;
+
+namespace Corgibytes.Freshli.Cli.Functionality.Git;
+
+public class CloneGitRepositoryActivity : IApplicationActivity
+{
+    [JsonProperty] private readonly string? _branch;
+    [JsonProperty] private readonly string _cacheDir;
+    [JsonProperty] private readonly string _gitPath;
+    [JsonProperty] private readonly ICachedGitSourceRepository _gitSourceRepository;
+    [JsonProperty] private readonly string _repoUrl;
+
+    public CloneGitRepositoryActivity(ICachedGitSourceRepository gitSourceRepository,
+        string repoUrl, string? branch, string cacheDir, string gitPath)
+    {
+        _gitSourceRepository = gitSourceRepository;
+        _repoUrl = repoUrl;
+        _branch = branch;
+        _cacheDir = cacheDir;
+        _gitPath = gitPath;
+    }
+
+    public void Handle(IApplicationEventEngine eventClient)
+    {
+        // Clone or pull the given repository and branch.
+        try
+        {
+            var gitRepository = _gitSourceRepository.CloneOrPull(_repoUrl, _branch, _cacheDir, _gitPath);
+            eventClient.Fire(new GitRepositoryClonedEvent { GitRepositoryId = gitRepository.Id });
+        }
+        catch (GitException e)
+        {
+            eventClient.Fire(new CloneGitRepositoryFailedEvent { ErrorMessage = e.Message });
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryFailedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryFailedEvent.cs
@@ -1,0 +1,12 @@
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+
+namespace Corgibytes.Freshli.Cli.Functionality.Git;
+
+public class CloneGitRepositoryFailedEvent : IApplicationEvent
+{
+    public string ErrorMessage { get; init; } = null!;
+
+    public void Handle(IApplicationActivityEngine eventClient)
+    {
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/Git/GitRepositoryClonedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/GitRepositoryClonedEvent.cs
@@ -1,0 +1,12 @@
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+
+namespace Corgibytes.Freshli.Cli.Functionality.Git;
+
+public class GitRepositoryClonedEvent : IApplicationEvent
+{
+    public string GitRepositoryId { get; init; } = null!;
+
+    public void Handle(IApplicationActivityEngine eventClient)
+    {
+    }
+}


### PR DESCRIPTION
Fixes #148 

This change ports the git clone repository command runner to invoke git clone repository using the new CQRS architecture.