### PR TITLE
Feature/git clone repository

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
@@ -1,5 +1,7 @@
+using System;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Exceptions;
+using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Functionality.Git;
 using Moq;
@@ -10,15 +12,19 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Git;
 [UnitTest]
 public class CloneGitRepositoryActivityTest
 {
-    private readonly string _branch;
+    private readonly Mock<IApplicationEventEngine> _eventEngine = new();
+    private readonly Mock<IServiceProvider> _serviceProvider = new();
+    private readonly Mock<ICacheManager> _cacheManager = new();
+    private readonly Mock<ICacheDb> _cacheDb = new();
+    private readonly Mock<ICachedGitSourceRepository> _gitSourceRepository = new();
 
     private readonly string _cacheDir;
-    private readonly Mock<IApplicationEventEngine> _eventEngine = new();
-    private readonly string _gitPath;
-    private readonly Mock<ICachedGitSourceRepository> _gitSourceRepository = new();
-    private readonly string _localPath;
-    private readonly string _repositoryId;
     private readonly string _url;
+    private readonly string? _branch;
+
+    private readonly string _gitPath;
+    private readonly string _repositoryId;
+    private readonly string _localPath;
 
     public CloneGitRepositoryActivityTest()
     {
@@ -29,6 +35,10 @@ public class CloneGitRepositoryActivityTest
         _gitPath = "git";
         _repositoryId = "test";
         _localPath = "test";
+
+        _serviceProvider.Setup(mock => mock.GetService(typeof(ICacheManager))).Returns(_cacheManager.Object);
+        _serviceProvider.Setup(mock => mock.GetService(typeof(ICachedGitSourceRepository))).Returns(_gitSourceRepository.Object);
+        _cacheManager.Setup(mock => mock.GetCacheDb(_cacheDir)).Returns(_cacheDb.Object);
     }
 
     [Fact]
@@ -57,5 +67,39 @@ public class CloneGitRepositoryActivityTest
 
         _eventEngine.Verify(mock =>
             mock.Fire(It.Is<CloneGitRepositoryFailedEvent>(value => value.ErrorMessage == "Git clone failed")));
+    }
+
+    [Fact]
+    public void HandlerFiresGitRepositoryClonedEventWhenAnalysisStarted()
+    {
+        // Saved analysis exists
+        var sampleGuid = new Guid();
+        const string historyInterval = "1m";
+        _cacheDb.Setup(mock => mock.RetrieveAnalysis(sampleGuid)).Returns(new CachedAnalysis(_url, _branch, historyInterval));
+        _gitSourceRepository.Setup(mock => mock.CloneOrPull(_url, _branch, _cacheDir, _gitPath)).Returns(new CachedGitSource(_repositoryId, _url, _branch, _localPath));
+
+        var activity = new CloneGitRepositoryActivity(_serviceProvider.Object, sampleGuid, _cacheDir, _gitPath);
+
+        activity.Handle(_eventEngine.Object);
+
+        _eventEngine.Verify(mock => mock.Fire(It.Is<GitRepositoryClonedEvent>(value => value.AnalysisId == sampleGuid)));
+    }
+
+    [Fact]
+    public void HandlerFiresCloneGitRepositoryFailedEventWhenAnalysisIsNotSaved()
+    {
+        // Saved analysis exists
+        var sampleGuid = new Guid();
+        const string historyInterval = "1m";
+        _cacheDb.Setup(mock => mock.RetrieveAnalysis(sampleGuid)).Returns(new CachedAnalysis(_url, _branch, historyInterval));
+
+        _gitSourceRepository.Setup(mock => mock.CloneOrPull(_url, _branch, _cacheDir, _gitPath))
+            .Throws(new GitException("Git clone failed"));
+
+        var activity = new CloneGitRepositoryActivity(_serviceProvider.Object, sampleGuid, _cacheDir, _gitPath);
+
+        activity.Handle(_eventEngine.Object);
+
+        _eventEngine.Verify(mock => mock.Fire(It.Is<CloneGitRepositoryFailedEvent>(value => value.ErrorMessage == "Git clone failed")));
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisStartedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisStartedEvent.cs
@@ -1,13 +1,21 @@
 using System;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.Git;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class AnalysisStartedEvent : IApplicationEvent
 {
+    private readonly IServiceProvider _serviceProvider = null!;
+
     public Guid AnalysisId { get; init; }
+
+    public string CacheDir { get; init; } = null!;
+
+    public string GitPath { get; init; } = null!;
 
     public void Handle(IApplicationActivityEngine eventClient)
     {
+        eventClient.Dispatch(new CloneGitRepositoryActivity(_serviceProvider, AnalysisId, CacheDir, GitPath));
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/CacheWasNotPreparedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/CacheWasNotPreparedEvent.cs
@@ -9,6 +9,7 @@ public class CacheWasNotPreparedEvent : ErrorEvent
 {
     public IServiceProvider ServiceProvider { get; init; } = null!;
 
+    public string GitPath { get; init; } = null!;
     public string CacheDirectory { get; init; } = null!;
     public string RepositoryUrl { get; init; } = null!;
     public string? RepositoryBranch { get; init; }
@@ -29,6 +30,7 @@ public class CacheWasNotPreparedEvent : ErrorEvent
             ServiceProvider.GetRequiredService<IHistoryIntervalParser>()
         )
         {
+            GitPath = GitPath,
             CacheDirectory = CacheDirectory,
             RepositoryUrl = RepositoryUrl,
             RepositoryBranch = RepositoryBranch,

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/StartAnalysisActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/StartAnalysisActivity.cs
@@ -13,6 +13,7 @@ public class StartAnalysisActivity : StartAnalysisActivityBase<CacheWasNotPrepar
             // TODO: Translate this string
             // ReSharper disable UseStringInterpolation
             ErrorMessage = string.Format("Unable to locate a valid cache directory at: '{0}'.", CacheDirectory),
+            GitPath = GitPath,
             CacheDirectory = CacheDirectory,
             RepositoryUrl = RepositoryUrl,
             RepositoryBranch = RepositoryBranch,

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/StartAnalysisActivityBase.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/StartAnalysisActivityBase.cs
@@ -12,6 +12,7 @@ public abstract class StartAnalysisActivityBase<TErrorEvent> : IApplicationActiv
         HistoryIntervalParser = historyIntervalParser;
     }
 
+    public string GitPath { get; init; } = null!;
     public string CacheDirectory { get; init; } = null!;
     public string RepositoryUrl { get; init; } = null!;
     public string? RepositoryBranch { get; init; }
@@ -26,7 +27,7 @@ public abstract class StartAnalysisActivityBase<TErrorEvent> : IApplicationActiv
     {
         var cacheDb = CacheManager.GetCacheDb(CacheDirectory);
         var id = cacheDb.SaveAnalysis(new CachedAnalysis(RepositoryUrl, RepositoryBranch, HistoryInterval));
-        eventClient.Fire(new AnalysisStartedEvent { AnalysisId = id });
+        eventClient.Fire(new AnalysisStartedEvent { AnalysisId = id, CacheDir = CacheDirectory, GitPath = GitPath});
     }
 
     private bool FireInvalidHistoryEventIfNeeded(IApplicationEventEngine eventClient)

--- a/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/CloneGitRepositoryActivity.cs
@@ -1,25 +1,48 @@
+using System;
 using Corgibytes.Freshli.Cli.Exceptions;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Git;
 
 public class CloneGitRepositoryActivity : IApplicationActivity
 {
-    [JsonProperty] private readonly string? _branch;
+    [JsonProperty] private readonly ICachedGitSourceRepository _gitSourceRepository;
+
     [JsonProperty] private readonly string _cacheDir;
     [JsonProperty] private readonly string _gitPath;
-    [JsonProperty] private readonly ICachedGitSourceRepository _gitSourceRepository;
-    [JsonProperty] private readonly string _repoUrl;
+    [JsonProperty] private readonly Guid _analysisId;
 
+    [JsonProperty] private readonly string _repoUrl;
+    [JsonProperty] private readonly string? _branch;
+
+    [JsonConstructor]
     public CloneGitRepositoryActivity(ICachedGitSourceRepository gitSourceRepository,
-        string repoUrl, string? branch, string cacheDir, string gitPath)
+        string repoUrl, string? branch, string cacheDir, string gitPath, Guid analysisId = new())
     {
         _gitSourceRepository = gitSourceRepository;
         _repoUrl = repoUrl;
         _branch = branch;
         _cacheDir = cacheDir;
         _gitPath = gitPath;
+        _analysisId = analysisId;
+    }
+
+    public CloneGitRepositoryActivity(IServiceProvider serviceProvider, Guid analysisId, string cacheDir, string gitPath)
+    {
+        _cacheDir = cacheDir;
+        _gitPath = gitPath;
+        _analysisId = analysisId;
+
+        _gitSourceRepository = serviceProvider.GetRequiredService<ICachedGitSourceRepository>();
+
+        var cacheManager = serviceProvider.GetRequiredService<ICacheManager>();
+        var cacheDb = cacheManager.GetCacheDb(_cacheDir);
+        var cachedAnalysis = cacheDb.RetrieveAnalysis(_analysisId);
+
+        _repoUrl = cachedAnalysis!.RepositoryUrl;
+        _branch = cachedAnalysis.RepositoryBranch;
     }
 
     public void Handle(IApplicationEventEngine eventClient)
@@ -28,7 +51,7 @@ public class CloneGitRepositoryActivity : IApplicationActivity
         try
         {
             var gitRepository = _gitSourceRepository.CloneOrPull(_repoUrl, _branch, _cacheDir, _gitPath);
-            eventClient.Fire(new GitRepositoryClonedEvent { GitRepositoryId = gitRepository.Id });
+            eventClient.Fire(new GitRepositoryClonedEvent { GitRepositoryId = gitRepository.Id, AnalysisId = _analysisId });
         }
         catch (GitException e)
         {

--- a/Corgibytes.Freshli.Cli/Functionality/Git/GitRepositoryClonedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/GitRepositoryClonedEvent.cs
@@ -1,3 +1,4 @@
+using System;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Git;
@@ -6,7 +7,11 @@ public class GitRepositoryClonedEvent : IApplicationEvent
 {
     public string GitRepositoryId { get; init; } = null!;
 
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    public Guid AnalysisId { get; init; }
+
     public void Handle(IApplicationActivityEngine eventClient)
     {
+        // TODO - Dispatch(ComputeHistoryActivity)
     }
 }


### PR DESCRIPTION
Fixes #215 

This change adds an interface that uses a saved analysis to determine the URL and branch to clone from in the CloneGitRepositoryActivity.  The saved analysis ID is then passed to the next stage of the pipeline from the GitRepositoryClonedEvent.

The cache directory and git path are still required to be passed to the CloneGitRepositoryActivity in order to find the saved analysis in the cacheDB and to find the git executable in order to execute the git command.