### PR TITLE
Service provider always null when used in Activities

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheWasNotPreparedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheWasNotPreparedEventTest.cs
@@ -19,7 +19,6 @@ public class CacheWasNotPreparedEventTest
 
         var cacheEvent = new CacheWasNotPreparedEvent
         {
-            ServiceProvider = serviceProvider.Object,
             CacheDirectory = "example",
             RepositoryUrl = "https://git.example.com",
             RepositoryBranch = "main",

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheWasNotPreparedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheWasNotPreparedEventTest.cs
@@ -30,6 +30,7 @@ public class CacheWasNotPreparedEventTest
             .Returns(historyIntervalParser.Object);
 
         var engine = new Mock<IApplicationActivityEngine>();
+        engine.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
 
         cacheEvent.Handle(engine.Object);
 

--- a/Corgibytes.Freshli.Cli.Test/ProgramTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/ProgramTest.cs
@@ -75,4 +75,15 @@ public class ProgramTest : FreshliTest
             "^ERROR|.*System.Exception: Simulating failure from an activity$", RegexOptions.Multiline
         ));
     }
+
+    [Fact]
+    public void ValidateServiceProviderIsLoaded()
+    {
+        MainCommand.ShouldIncludeLoadServiceCommand = true;
+        var task = Task.Run(() => Program.Main("load-service"));
+        task.Wait();
+
+        _consoleOutput.ToString().Should().Contain("All good! Service provider is not null.");
+        _consoleOutput.ToString().Should().NotContain("Simulating loading the service provider, but the provider is null.");
+    }
 }

--- a/Corgibytes.Freshli.Cli/CommandRunners/LoadServiceCommandRunner.cs
+++ b/Corgibytes.Freshli.Cli/CommandRunners/LoadServiceCommandRunner.cs
@@ -10,12 +10,9 @@ namespace Corgibytes.Freshli.Cli.CommandRunners;
 
 public class LoadServiceCommandRunner : CommandRunner<LoadServiceCommand, EmptyCommandOptions>
 {
-    private readonly IServiceProvider _serviceProvider;
-
     public LoadServiceCommandRunner(IServiceProvider serviceProvider, Runner runner, IApplicationActivityEngine activityEngine)
         : base(serviceProvider, runner)
     {
-        _serviceProvider = serviceProvider;
         ActivityEngine = activityEngine;
     }
 
@@ -23,7 +20,7 @@ public class LoadServiceCommandRunner : CommandRunner<LoadServiceCommand, EmptyC
 
     public override int Run(EmptyCommandOptions options, InvocationContext context)
     {
-        ActivityEngine.Dispatch(new LoadServiceProviderActivity(_serviceProvider));
+        ActivityEngine.Dispatch(new LoadServiceProviderActivity());
         ActivityEngine.Wait();
         return 0;
     }

--- a/Corgibytes.Freshli.Cli/CommandRunners/LoadServiceCommandRunner.cs
+++ b/Corgibytes.Freshli.Cli/CommandRunners/LoadServiceCommandRunner.cs
@@ -1,0 +1,30 @@
+using System;
+using System.CommandLine.Invocation;
+using Corgibytes.Freshli.Cli.CommandOptions;
+using Corgibytes.Freshli.Cli.Commands;
+using Corgibytes.Freshli.Cli.Functionality;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Lib;
+
+namespace Corgibytes.Freshli.Cli.CommandRunners;
+
+public class LoadServiceCommandRunner : CommandRunner<LoadServiceCommand, EmptyCommandOptions>
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public LoadServiceCommandRunner(IServiceProvider serviceProvider, Runner runner, IApplicationActivityEngine activityEngine)
+        : base(serviceProvider, runner)
+    {
+        _serviceProvider = serviceProvider;
+        ActivityEngine = activityEngine;
+    }
+
+    private IApplicationActivityEngine ActivityEngine { get; }
+
+    public override int Run(EmptyCommandOptions options, InvocationContext context)
+    {
+        ActivityEngine.Dispatch(new LoadServiceProviderActivity(_serviceProvider));
+        ActivityEngine.Wait();
+        return 0;
+    }
+}

--- a/Corgibytes.Freshli.Cli/Commands/LoadServiceCommand.cs
+++ b/Corgibytes.Freshli.Cli/Commands/LoadServiceCommand.cs
@@ -1,0 +1,10 @@
+using Corgibytes.Freshli.Cli.CommandOptions;
+
+namespace Corgibytes.Freshli.Cli.Commands;
+
+public class LoadServiceCommand : RunnableCommand<LoadServiceCommand, EmptyCommandOptions>
+{
+    public LoadServiceCommand() : base("load-service", "Loads a service to test if the dependency injection is working accordingly.")
+    {
+    }
+}

--- a/Corgibytes.Freshli.Cli/Commands/MainCommand.cs
+++ b/Corgibytes.Freshli.Cli/Commands/MainCommand.cs
@@ -32,7 +32,13 @@ public class MainCommand : RootCommand
         {
             Add(new FailCommand());
         }
+
+        if (ShouldIncludeLoadServiceCommand)
+        {
+            Add(new LoadServiceCommand());
+        }
     }
 
     public static bool ShouldIncludeFailCommand { get; set; }
+    public static bool ShouldIncludeLoadServiceCommand { get; set; }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/CacheWasNotPreparedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/CacheWasNotPreparedEvent.cs
@@ -1,4 +1,3 @@
-using System;
 using Corgibytes.Freshli.Cli.CommandRunners.Cache;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,8 +6,6 @@ namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class CacheWasNotPreparedEvent : ErrorEvent
 {
-    public IServiceProvider ServiceProvider { get; init; } = null!;
-
     public string GitPath { get; init; } = null!;
     public string CacheDirectory { get; init; } = null!;
     public string RepositoryUrl { get; init; } = null!;
@@ -26,8 +23,8 @@ public class CacheWasNotPreparedEvent : ErrorEvent
         });
 
         eventClient.Dispatch(new RestartAnalysisActivity(
-            ServiceProvider.GetRequiredService<ICacheManager>(),
-            ServiceProvider.GetRequiredService<IHistoryIntervalParser>()
+            eventClient.ServiceProvider.GetRequiredService<ICacheManager>(),
+            eventClient.ServiceProvider.GetRequiredService<IHistoryIntervalParser>()
         )
         {
             GitPath = GitPath,

--- a/Corgibytes.Freshli.Cli/Functionality/Engine/ApplicationEngine.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Engine/ApplicationEngine.cs
@@ -18,11 +18,13 @@ public class ApplicationEngine : IApplicationEventEngine, IApplicationActivityEn
     private static bool s_isActivityDispatchingInProgress;
     private static bool s_isEventFiringInProgress;
     private readonly ILogger<ApplicationEngine> _logger;
+    public IServiceProvider ServiceProvider { get; }
 
-    public ApplicationEngine(IBackgroundJobClient jobClient, ILogger<ApplicationEngine> logger)
+    public ApplicationEngine(IBackgroundJobClient jobClient, ILogger<ApplicationEngine> logger, IServiceProvider serviceProvider)
     {
         JobClient = jobClient ?? throw new ArgumentNullException(nameof(jobClient));
         _logger = logger;
+        ServiceProvider = serviceProvider;
     }
 
     private IBackgroundJobClient JobClient { get; }

--- a/Corgibytes.Freshli.Cli/Functionality/Engine/IApplicationActivityEngine.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Engine/IApplicationActivityEngine.cs
@@ -1,7 +1,11 @@
+using System;
+
 namespace Corgibytes.Freshli.Cli.Functionality.Engine;
 
 public interface IApplicationActivityEngine
 {
+    public IServiceProvider ServiceProvider { get; }
+
     public void Dispatch(IApplicationActivity applicationActivity);
     public void Wait();
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Engine/IApplicationEventEngine.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Engine/IApplicationEventEngine.cs
@@ -4,6 +4,8 @@ namespace Corgibytes.Freshli.Cli.Functionality.Engine;
 
 public interface IApplicationEventEngine
 {
+    public IServiceProvider ServiceProvider { get; }
+
     public void Fire(IApplicationEvent applicationEvent);
     public void On<TEvent>(Action<TEvent> eventHandler) where TEvent : IApplicationEvent;
 }

--- a/Corgibytes.Freshli.Cli/Functionality/LoadServiceProviderActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/LoadServiceProviderActivity.cs
@@ -1,0 +1,24 @@
+using System;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+
+namespace Corgibytes.Freshli.Cli.Functionality;
+
+public class LoadServiceProviderActivity : IApplicationActivity
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public LoadServiceProviderActivity(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public void Handle(IApplicationEventEngine eventClient)
+    {
+        if (_serviceProvider == null)
+        {
+            throw new Exception("Simulating loading the service provider, but the provider is null.");
+        }
+
+        throw new Exception("All good! Service provider is not null.");
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/LoadServiceProviderActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/LoadServiceProviderActivity.cs
@@ -5,16 +5,9 @@ namespace Corgibytes.Freshli.Cli.Functionality;
 
 public class LoadServiceProviderActivity : IApplicationActivity
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    public LoadServiceProviderActivity(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
     public void Handle(IApplicationEventEngine eventClient)
     {
-        if (_serviceProvider == null)
+        if (eventClient.ServiceProvider == null)
         {
             throw new Exception("Simulating loading the service provider, but the provider is null.");
         }

--- a/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
+++ b/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
@@ -43,6 +43,7 @@ public class FreshliServiceBuilder
         Services.AddSingleton<IAgentManager, AgentManager>();
         RegisterBaseCommand();
         RegisterFailCommand();
+        RegisterLoadServiceCommand();
         RegisterScanCommand();
         RegisterCacheCommand();
         RegisterAgentsCommand();
@@ -55,6 +56,9 @@ public class FreshliServiceBuilder
 
     private void RegisterFailCommand() =>
         Services.AddScoped<ICommandRunner<FailCommand, EmptyCommandOptions>, FailCommandRunner>();
+
+    private void RegisterLoadServiceCommand() =>
+        Services.AddScoped<ICommandRunner<LoadServiceCommand, EmptyCommandOptions>, LoadServiceCommandRunner>();
 
     private void RegisterScanCommand()
     {


### PR DESCRIPTION
I've tested a few things before ending up on this solution. 

## `JsonContractResolver`

What I started with was @mscottford suggestion to use the `JsonContractResolver`:
```csharp
...
        else if (objectType == typeof(IServiceProvider))
        {
            var serviceProvider = _serviceScopeFactory.CreateScope().ServiceProvider;

            if (serviceProvider != null)
            {
                baseContract.DefaultCreator = () => serviceProvider;
            }
        }
...
```
This results in a self referencing loop, though. Potential solutions online for this problem are either: ignore it, ignore it globally or remove it. Ignoring it with `[JsonIgnore]` does make the loop error go away, but it also ignores the contract resolver.

Examples:
https://makolyte.com/newtonsoft-json-jsonserializationexception-self-referencing-loop-detected-for-property/

## Pass the service collection into the handle method

```csharp
public interface IApplicationActivity
{
    public void Handle(IApplicationEventEngine eventClient, IServiceProvider);
}
```

So, this does work. One of the concerns was that it might not work because it also gets serialized. Running the test added in https://github.com/corgibytes/freshli-cli/commit/d64cbdd26b274a1c56a933166c4657bbd3279283 did not show any problems with serializing. A concern I do have is that the objects enqueued will be huge with the entire service provider added unless there's some hidden things going on that reduces it. I did not look into this because I had an epiphany. 

## Solution proposed

The epiphany I had was when step debugging the previous solution with adding it to the Handle is that I had the ServiceProvider available in the ApplicationEngine. Instead of going the long way, I've made it a public property so from an Activity you are able to call the Provider directly. This way it doesn't need to be injected and it doesn't get serialized. 

I think long-term we should still move towards splitting up the Activities from their Handlers. What this PR proposes is basically using the container as a Service Locator which has been described as an anti-pattern by some. I personally prefer to have dependency injection as well as testing things with service locators feel cumbersome. But I also know I'm biased.

https://blog.ploeh.dk/2010/02/03/ServiceLocatorisanAnti-Pattern/
> Let's examine why this is so. In short, the problem with Service Locator is that it hides a class' dependencies, causing run-time errors instead of compile-time errors, as well as making the code more difficult to maintain because it becomes unclear when you would be introducing a breaking change. 