### PR TITLE
Make the fields of AnalysisLocation public

### DIFF
--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
@@ -4,9 +4,9 @@ namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class AnalysisLocation : IAnalysisLocation
 {
-    [JsonProperty] public string CacheDirectory { get; }
-    [JsonProperty] public string RepositoryId { get; }
-    [JsonProperty] public string? CommitId { get; }
+    public string CacheDirectory { get; }
+    public string RepositoryId { get; }
+    public string? CommitId { get; }
 
     public AnalysisLocation(string cacheDirectory, string repositoryId, string? commitId = null)
     {

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class AnalysisLocation : IAnalysisLocation

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AnalysisLocation.cs
@@ -4,14 +4,14 @@ namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class AnalysisLocation : IAnalysisLocation
 {
-    [JsonProperty] private readonly string _cacheDirectory;
-    [JsonProperty] private readonly string _repositoryId;
-    [JsonProperty] public readonly string? CommitId;
+    [JsonProperty] public string CacheDirectory { get; }
+    [JsonProperty] public string RepositoryId { get; }
+    [JsonProperty] public string? CommitId { get; }
 
     public AnalysisLocation(string cacheDirectory, string repositoryId, string? commitId = null)
     {
-        _cacheDirectory = cacheDirectory;
-        _repositoryId = repositoryId;
+        CacheDirectory = cacheDirectory;
+        RepositoryId = repositoryId;
         CommitId = commitId;
     }
 
@@ -21,10 +21,10 @@ public class AnalysisLocation : IAnalysisLocation
         {
             if (CommitId == null)
             {
-                return System.IO.Path.Combine(_cacheDirectory, "repositories", _repositoryId);
+                return System.IO.Path.Combine(CacheDirectory, "repositories", RepositoryId);
             }
 
-            return System.IO.Path.Combine(_cacheDirectory, "histories", _repositoryId, CommitId);
+            return System.IO.Path.Combine(CacheDirectory, "histories", RepositoryId, CommitId);
         }
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/IAnalysisLocation.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/IAnalysisLocation.cs
@@ -1,6 +1,10 @@
+// ReSharper disable UnusedMemberInSuper.Global
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public interface IAnalysisLocation
 {
+    public string CacheDirectory { get; }
+    public string RepositoryId { get; }
+    public string? CommitId { get; }
     public string Path { get; }
 }


### PR DESCRIPTION
In several places we've been wanting to re-use this object for more then just the Path. It's been our identifier for the analysis. Instead of passing cache directory, repository, and optionally commit identifier to each thing the entire time. Just pass the AnalysisLocation