### PR TITLE
Fixes for compute history and checkout history activities

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
@@ -65,8 +65,9 @@ public class ComputeHistoryActivityTest
             mock => mock.Fire(
                 It.Is<HistoryIntervalStopFoundEvent>(
                     value =>
-                        value.GitCommitIdentifier == "75c7fcc7336ee718050c4a5c8dfb5598622787b2" &&
-                        value.AnalysisLocation == analysisLocation.Object
+                        value.GitExecutablePath == "git" &&
+                        value.AnalysisLocation != null &&
+                        value.AnalysisLocation.CommitId == "75c7fcc7336ee718050c4a5c8dfb5598622787b2"
                 )
             )
         );
@@ -74,8 +75,9 @@ public class ComputeHistoryActivityTest
             mock => mock.Fire(
                 It.Is<HistoryIntervalStopFoundEvent>(
                     value =>
-                        value.GitCommitIdentifier == "583d813db3e28b9b44a29db352e2f0e1b4c6e420" &&
-                        value.AnalysisLocation == analysisLocation.Object
+                        value.GitExecutablePath == "git" &&
+                        value.AnalysisLocation != null &&
+                        value.AnalysisLocation.CommitId == "583d813db3e28b9b44a29db352e2f0e1b4c6e420"
                 )
             )
         );
@@ -125,8 +127,9 @@ public class ComputeHistoryActivityTest
             mock => mock.Fire(
                 It.Is<HistoryIntervalStopFoundEvent>(
                     value =>
-                        value.GitCommitIdentifier == "75c7fcc7336ee718050c4a5c8dfb5598622787b2" &&
-                        value.AnalysisLocation == analysisLocation.Object
+                        value.GitExecutablePath == "git" &&
+                        value.AnalysisLocation != null &&
+                        value.AnalysisLocation.CommitId == "75c7fcc7336ee718050c4a5c8dfb5598622787b2"
                 )
             )
         );

--- a/Corgibytes.Freshli.Cli/Functionality/History/CheckoutHistoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/CheckoutHistoryActivity.cs
@@ -7,35 +7,30 @@ namespace Corgibytes.Freshli.Cli.Functionality.History;
 
 public class CheckoutHistoryActivity : IApplicationActivity
 {
-    [JsonProperty] private readonly string _cacheDirectory;
-    [JsonProperty] private readonly string? _commitId;
     [JsonProperty] private readonly string _gitExecutablePath;
     [JsonProperty] private readonly IGitManager _gitManager;
-    [JsonProperty] private readonly string _repositoryId;
+    [JsonProperty] private readonly IAnalysisLocation _analysisLocation;
 
     public CheckoutHistoryActivity(IGitManager gitManager, string gitExecutablePath,
         IAnalysisLocation analysisLocation)
     {
         _gitManager = gitManager;
         _gitExecutablePath = gitExecutablePath;
-        _cacheDirectory = analysisLocation.CacheDirectory;
-        _repositoryId = analysisLocation.RepositoryId;
-        _commitId = analysisLocation.CommitId;
+        _analysisLocation = analysisLocation;
     }
 
     public void Handle(IApplicationEventEngine eventClient)
     {
-        if (_commitId != null)
+        if (_analysisLocation.CommitId != null)
         {
             _gitManager.CreateArchive(
-                _repositoryId,
-                _cacheDirectory,
-                _gitManager.ParseCommitId(_commitId),
+                _analysisLocation.RepositoryId,
+                _analysisLocation.CacheDirectory,
+                _gitManager.ParseCommitId(_analysisLocation.CommitId),
                 _gitExecutablePath
             );
 
-            eventClient.Fire(
-                new HistoryStopCheckedOutEvent(new AnalysisLocation(_cacheDirectory, _repositoryId, _commitId)));
+            eventClient.Fire(new HistoryStopCheckedOutEvent{ AnalysisLocation = _analysisLocation });
         }
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/History/ComputeHistoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/ComputeHistoryActivity.cs
@@ -48,11 +48,13 @@ public class ComputeHistoryActivity : IApplicationActivity
 
         foreach (var historyIntervalStop in historyIntervalStops)
         {
+            var historyStopLocation = new AnalysisLocation(AnalysisLocation.CacheDirectory,
+                AnalysisLocation.RepositoryId, historyIntervalStop.GitCommitIdentifier);
+
             eventClient.Fire(new HistoryIntervalStopFoundEvent
             {
                 GitExecutablePath = GitExecutablePath,
-                GitCommitIdentifier = historyIntervalStop.GitCommitIdentifier,
-                AnalysisLocation = AnalysisLocation
+                AnalysisLocation = historyStopLocation
             });
         }
     }

--- a/Corgibytes.Freshli.Cli/Functionality/History/HistoryIntervalStopFoundEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/HistoryIntervalStopFoundEvent.cs
@@ -7,8 +7,6 @@ namespace Corgibytes.Freshli.Cli.Functionality.History;
 
 public class HistoryIntervalStopFoundEvent : IApplicationEvent
 {
-
-    public string? GitCommitIdentifier { get; init; }
     public IAnalysisLocation? AnalysisLocation { get; init; }
     public string? GitExecutablePath { get; init; }
 

--- a/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
@@ -8,8 +8,7 @@ namespace Corgibytes.Freshli.Cli.Functionality.History;
 
 public class HistoryStopCheckedOutEvent : IApplicationEvent
 {
-    public HistoryStopCheckedOutEvent(IAnalysisLocation analysisLocation) => AnalysisLocation = analysisLocation;
-    public IAnalysisLocation AnalysisLocation { get; }
+    public IAnalysisLocation AnalysisLocation { get; init; } = null!;
 
     public void Handle(IApplicationActivityEngine eventClient)
     {


### PR DESCRIPTION
Fixes deserialization of CheckoutHistoryActivity - because analysisLocation was being used to initialize _cacheDirectory, _repositoryId, and _commitId, but was not saved in the object, the values were not being deserialized correctly when the activity ran.  This change saves _analysisLocation in the object instead and uses _analysisLocation directly in Handle.  This change also passes _analysisLocation to HistoryStopCheckedOutEvent instead of creating a new AnalysisLocation instance.

Fixes HistoryIntervalStopFoundEvent which was expecting the Git commit Id to be provided in AnalysisLocation and was not using the GitCommitIdentifier field. This change also creates a new historyStopLocation and passes that to the event instead of overwriting the values in the same AnalysisLocation which *may* work depending on when the object is serialized, but feels unnecessarily risky.