### PR TITLE
Gets AgentReader from IAgentManager via the eventClient.ServiceProvider

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
@@ -1,6 +1,5 @@
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
 using Moq;
 using Xunit;
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
@@ -12,10 +12,9 @@ public class AgentDetectedForDetectManifestEventTest
     [Fact]
     public void Handle()
     {
+        const string agentExecutablePath = "/path/to/agent";
         var analysisLocation = new Mock<IAnalysisLocation>();
-        var agentReader = new Mock<IAgentReader>();
-
-        var appEvent = new AgentDetectedForDetectManifestEvent(analysisLocation.Object, agentReader.Object);
+        var appEvent = new AgentDetectedForDetectManifestEvent(analysisLocation.Object, agentExecutablePath);
 
         var activityEngine = new Mock<IApplicationActivityEngine>();
 
@@ -24,6 +23,6 @@ public class AgentDetectedForDetectManifestEventTest
         activityEngine.Verify(mock =>
             mock.Dispatch(It.Is<DetectManifestsUsingAgentActivity>(activity =>
                 activity.AnalysisLocation == analysisLocation.Object &&
-                activity.AgentReader == agentReader.Object)));
+                activity.AgentExecutablePath == agentExecutablePath)));
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
@@ -24,20 +25,28 @@ public class DetectManifestsUsingAgentActivityTest
                 "/path/to/second/manifest"
             });
 
-        var activity = new DetectManifestsUsingAgentActivity(analysisLocation.Object, agentReader.Object);
+        const string agentExecutablePath = "/path/to/agent";
+        var agentManager = new Mock<IAgentManager>();
+        agentManager.Setup(mock => mock.GetReader(agentExecutablePath)).Returns(agentReader.Object);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(mock => mock.GetService(typeof(IAgentManager))).Returns(agentManager.Object);
 
         var eventEngine = new Mock<IApplicationEventEngine>();
+        eventEngine.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
+
+        var activity = new DetectManifestsUsingAgentActivity(analysisLocation.Object, agentExecutablePath);
 
         activity.Handle(eventEngine.Object);
 
         eventEngine.Verify(mock => mock.Fire(It.Is<ManifestDetectedEvent>(appEvent =>
             appEvent.AnalysisLocation == analysisLocation.Object &&
-            appEvent.AgentReader == agentReader.Object &&
+            appEvent.AgentExecutablePath == agentExecutablePath &&
             appEvent.ManifestPath == "/path/to/first/manifest")));
 
         eventEngine.Verify(mock => mock.Fire(It.Is<ManifestDetectedEvent>(appEvent =>
             appEvent.AnalysisLocation == analysisLocation.Object &&
-            appEvent.AgentReader == agentReader.Object &&
+            appEvent.AgentExecutablePath == agentExecutablePath &&
             appEvent.ManifestPath == "/path/to/second/manifest")));
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
@@ -15,23 +15,19 @@ public class ManifestDetectedEventTest
     public void CorrectlyDispatchesGenerateBillOfMaterialsActivity()
     {
         var manifestPath = "/path/to/manifest";
-        var billOfMaterialsPath = "/path/to/bom";
         var analysisLocation = new AnalysisLocation("/cache/directory", "2dbc2fd2358e1ea1b7a6bc08ea647b9a337ac92d",
             "da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
-        var javaAgentReader = new Mock<IAgentReader>();
-
-        javaAgentReader.Setup(mock => mock.ProcessManifest(manifestPath, It.IsAny<DateTime>())).Returns(billOfMaterialsPath);
-
         var engine = new Mock<IApplicationActivityEngine>();
 
-        var manifestEvent = new ManifestDetectedEvent(analysisLocation, javaAgentReader.Object, manifestPath);
+        const string agentExecutablePath = "/path/to/agent";
+        var manifestEvent = new ManifestDetectedEvent(analysisLocation, agentExecutablePath, manifestPath);
         manifestEvent.Handle(engine.Object);
 
         engine.Verify(mock => mock.Dispatch(It.Is<GenerateBillOfMaterialsActivity>(value =>
             value.AnalysisLocation == analysisLocation &&
             value.ManifestPath == manifestPath &&
-            value.AgentReader == javaAgentReader.Object
+            value.AgentExecutablePath == agentExecutablePath
         )));
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
@@ -1,8 +1,6 @@
-using System;
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
 using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
 using Moq;
 using Xunit;
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
@@ -15,14 +15,22 @@ public class GenerateBillOfMaterialsActivityTest
     {
         // Arrange
         var javaAgentReader = new Mock<IAgentReader>();
-        var eventEngine = new Mock<IApplicationEventEngine>();
-        var analysisLocation = new Mock<IAnalysisLocation>();
-
         javaAgentReader.Setup(mock => mock.ProcessManifest("/path/to/manifest", It.IsAny<DateTime>()))
             .Returns("/path/to/bill-of-materials");
 
+        const string agentExecutablePath = "/path/to/agent";
+        var agentManager = new Mock<IAgentManager>();
+        agentManager.Setup(mock => mock.GetReader(agentExecutablePath)).Returns(javaAgentReader.Object);
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(mock => mock.GetService(typeof(IAgentManager))).Returns(agentManager.Object);
+
+        var eventEngine = new Mock<IApplicationEventEngine>();
+        eventEngine.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
+
         // Act
-        var activity = new GenerateBillOfMaterialsActivity(javaAgentReader.Object, analysisLocation.Object, "/path/to/manifest");
+        var analysisLocation = new Mock<IAnalysisLocation>();
+        var activity = new GenerateBillOfMaterialsActivity(agentExecutablePath, analysisLocation.Object, "/path/to/manifest");
         activity.Handle(eventEngine.Object);
 
         // Assert

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AgentDetectedForDetectManifestEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AgentDetectedForDetectManifestEvent.cs
@@ -5,15 +5,15 @@ namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class AgentDetectedForDetectManifestEvent : IApplicationEvent
 {
-    public AgentDetectedForDetectManifestEvent(IAnalysisLocation analysisLocation, IAgentReader agentReader)
+    public AgentDetectedForDetectManifestEvent(IAnalysisLocation analysisLocation, string agentExecutablePath)
     {
         AnalysisLocation = analysisLocation;
-        AgentReader = agentReader;
+        AgentExecutablePath = agentExecutablePath;
     }
 
     public IAnalysisLocation AnalysisLocation { get; }
-    public IAgentReader AgentReader { get; }
+    public string AgentExecutablePath { get; }
 
     public void Handle(IApplicationActivityEngine eventClient) =>
-        eventClient.Dispatch(new DetectManifestsUsingAgentActivity(AnalysisLocation, AgentReader));
+        eventClient.Dispatch(new DetectManifestsUsingAgentActivity(AnalysisLocation, AgentExecutablePath));
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/AgentDetectedForDetectManifestEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/AgentDetectedForDetectManifestEvent.cs
@@ -1,5 +1,4 @@
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/DetectAgentsForDetectManifestsActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/DetectAgentsForDetectManifestsActivity.cs
@@ -1,31 +1,25 @@
 using Corgibytes.Freshli.Cli.Commands;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class DetectAgentsForDetectManifestsActivity : IApplicationActivity
 {
-    [JsonProperty] private readonly IAgentManager _agentManager;
-    [JsonProperty] private readonly IAgentsDetector _agentsDetector;
     [JsonProperty] private readonly IAnalysisLocation _analysisLocation;
 
-
-    public DetectAgentsForDetectManifestsActivity(IAgentsDetector agentsDetector, IAgentManager agentManager,
-        IAnalysisLocation analysisLocation)
+    public DetectAgentsForDetectManifestsActivity(IAnalysisLocation analysisLocation)
     {
-        _agentsDetector = agentsDetector;
-        _agentManager = agentManager;
         _analysisLocation = analysisLocation;
     }
 
     public void Handle(IApplicationEventEngine eventClient)
     {
-        foreach (var agentPath in _agentsDetector.Detect())
+        var agentsDetector = eventClient.ServiceProvider.GetRequiredService<IAgentsDetector>();
+        foreach (var agentPath in agentsDetector.Detect())
         {
-            eventClient.Fire(new AgentDetectedForDetectManifestEvent(
-                _analysisLocation, _agentManager.GetReader(agentPath)));
+            eventClient.Fire(new AgentDetectedForDetectManifestEvent(_analysisLocation, agentPath));
         }
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/DetectManifestsUsingAgentActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/DetectManifestsUsingAgentActivity.cs
@@ -1,24 +1,27 @@
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class DetectManifestsUsingAgentActivity : IApplicationActivity
 {
-    public DetectManifestsUsingAgentActivity(IAnalysisLocation analysisLocation, IAgentReader agentReader)
+    public DetectManifestsUsingAgentActivity(IAnalysisLocation analysisLocation, string agentExecutablePath)
     {
         AnalysisLocation = analysisLocation;
-        AgentReader = agentReader;
+        AgentExecutablePath = agentExecutablePath;
     }
 
     public IAnalysisLocation AnalysisLocation { get; }
-    public IAgentReader AgentReader { get; }
+    public string AgentExecutablePath { get; }
 
     public void Handle(IApplicationEventEngine eventClient)
     {
-        foreach (var manifestPath in AgentReader.DetectManifests(AnalysisLocation.Path))
+        var agentManager = eventClient.ServiceProvider.GetRequiredService<IAgentManager>();
+        var agentReader = agentManager.GetReader(AgentExecutablePath);
+        foreach (var manifestPath in agentReader.DetectManifests(AnalysisLocation.Path))
         {
-            eventClient.Fire(new ManifestDetectedEvent(AnalysisLocation, AgentReader, manifestPath));
+            eventClient.Fire(new ManifestDetectedEvent(AnalysisLocation, AgentExecutablePath, manifestPath));
         }
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/ManifestDetectedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/ManifestDetectedEvent.cs
@@ -1,6 +1,5 @@
 using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/ManifestDetectedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/ManifestDetectedEvent.cs
@@ -6,19 +6,19 @@ namespace Corgibytes.Freshli.Cli.Functionality.Analysis;
 
 public class ManifestDetectedEvent : IApplicationEvent
 {
-    public ManifestDetectedEvent(IAnalysisLocation analysisLocation, IAgentReader agentReader, string manifestPath)
+    public ManifestDetectedEvent(IAnalysisLocation analysisLocation, string agentExecutablePath, string manifestPath)
     {
         AnalysisLocation = analysisLocation;
-        AgentReader = agentReader;
+        AgentExecutablePath = agentExecutablePath;
         ManifestPath = manifestPath;
     }
 
     public IAnalysisLocation AnalysisLocation { get; }
-    public IAgentReader AgentReader { get; }
+    public string AgentExecutablePath { get; }
     public string ManifestPath { get; }
 
     public void Handle(IApplicationActivityEngine eventClient) => eventClient.Dispatch(new GenerateBillOfMaterialsActivity(
-        AgentReader,
+        AgentExecutablePath,
         AnalysisLocation,
         ManifestPath
     ));

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
@@ -2,26 +2,30 @@ using System;
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 
 public class GenerateBillOfMaterialsActivity : IApplicationActivity
 {
-    public readonly IAgentReader AgentReader;
+    public readonly string AgentExecutablePath;
     public readonly IAnalysisLocation AnalysisLocation;
     public readonly string ManifestPath;
 
-    public GenerateBillOfMaterialsActivity(IAgentReader agentReader, IAnalysisLocation analysisLocation, string manifestPath)
+    public GenerateBillOfMaterialsActivity(string agentExecutablePath, IAnalysisLocation analysisLocation, string manifestPath)
     {
-        AgentReader = agentReader;
+        AgentExecutablePath = agentExecutablePath;
         AnalysisLocation = analysisLocation;
         ManifestPath = manifestPath;
     }
 
     public void Handle(IApplicationEventEngine eventClient)
     {
+        var agentManager = eventClient.ServiceProvider.GetRequiredService<IAgentManager>();
+        var agentReader = agentManager.GetReader(AgentExecutablePath);
+
         var asOfDate = DateTime.Now;
-        var pathToBillOfMaterials = AgentReader.ProcessManifest(ManifestPath, asOfDate);
+        var pathToBillOfMaterials = agentReader.ProcessManifest(ManifestPath, asOfDate);
 
         eventClient.Fire(new BillOfMaterialsGeneratedEvent(AnalysisLocation, pathToBillOfMaterials));
     }

--- a/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
@@ -12,8 +12,6 @@ public class HistoryStopCheckedOutEvent : IApplicationEvent
 
     public void Handle(IApplicationActivityEngine eventClient)
     {
-        eventClient.Dispatch(new DetectAgentsForDetectManifestsActivity(
-            eventClient.ServiceProvider.GetRequiredService<IAgentsDetector>(),  eventClient.ServiceProvider.GetRequiredService<IAgentManager>(),
-            AnalysisLocation));
+        eventClient.Dispatch(new DetectAgentsForDetectManifestsActivity(AnalysisLocation));
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/HistoryStopCheckedOutEvent.cs
@@ -1,8 +1,5 @@
-using Corgibytes.Freshli.Cli.Commands;
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
-using Corgibytes.Freshli.Cli.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Corgibytes.Freshli.Cli.Functionality.History;
 


### PR DESCRIPTION
This changes the chain of activities in the analyze command to pass the agentExecutablePath instead of serializing/deserializing the IAgentReader object.