### PR TITLE
Returns and empty list of detect-manifests returns an empty string

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -44,8 +44,31 @@ public class AgentReaderTest
         checkoutDirectory.Delete(true);
     }
 
+    [Fact]
+    public void AgentReaderReturnsEmptyListWhenNoManifestsFound()
+    {
+        var checkoutLocation = CreateCheckoutLocation(out var checkoutDirectory);
+        var reader = new AgentReader("freshli-agent-java");
+        var repositoryLocation = Path.Combine(checkoutLocation, "invalid_repository");
+
+        var actualManifests = reader.DetectManifests(repositoryLocation);
+        Assert.Empty(actualManifests);
+    }
+
     private static void SetupDirectory(out string repositoryLocation, out AgentReader reader,
         out DirectoryInfo checkoutDirectory)
+    {
+        var checkoutLocation = CreateCheckoutLocation(out checkoutDirectory);
+
+        // clone https://github.com/protocolbuffers/protobuf to a temp location
+        Invoke.Command("git", "clone https://github.com/protocolbuffers/protobuf", checkoutLocation);
+
+        repositoryLocation = Path.Combine(checkoutLocation, "protobuf");
+
+        reader = new AgentReader("freshli-agent-java");
+    }
+
+    private static string CreateCheckoutLocation(out DirectoryInfo checkoutDirectory)
     {
         var checkoutLocation = Path.Combine(Path.GetTempPath(), "repositories");
 
@@ -56,12 +79,6 @@ public class AgentReaderTest
         }
 
         checkoutDirectory.Create();
-
-        // clone https://github.com/protocolbuffers/protobuf to a temp location
-        Invoke.Command("git", "clone https://github.com/protocolbuffers/protobuf", checkoutLocation);
-
-        repositoryLocation = Path.Combine(checkoutLocation, "protobuf");
-
-        reader = new AgentReader("freshli-agent-java");
+        return checkoutLocation;
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -47,7 +47,7 @@ public class AgentReaderTest
     [Fact]
     public void AgentReaderReturnsEmptyListWhenNoManifestsFound()
     {
-        var checkoutLocation = CreateCheckoutLocation(out var checkoutDirectory);
+        var checkoutLocation = CreateCheckoutLocation(out checkoutDirectory);
         var reader = new AgentReader("freshli-agent-java");
         var repositoryLocation = Path.Combine(checkoutLocation, "invalid_repository");
 

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -47,12 +47,13 @@ public class AgentReaderTest
     [Fact]
     public void AgentReaderReturnsEmptyListWhenNoManifestsFound()
     {
-        var checkoutLocation = CreateCheckoutLocation(out checkoutDirectory);
+        var checkoutLocation = CreateCheckoutLocation(out var checkoutDirectory);
         var reader = new AgentReader("freshli-agent-java");
         var repositoryLocation = Path.Combine(checkoutLocation, "invalid_repository");
 
         var actualManifests = reader.DetectManifests(repositoryLocation);
         Assert.Empty(actualManifests);
+        checkoutDirectory.Delete();
     }
 
     private static void SetupDirectory(out string repositoryLocation, out AgentReader reader,

--- a/Corgibytes.Freshli.Cli/Services/AgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentReader.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Corgibytes.Freshli.Cli.Extensions;
 using Corgibytes.Freshli.Cli.Functionality;
 using PackageUrl;
+using ServiceStack;
 
 namespace Corgibytes.Freshli.Cli.Services;
 
@@ -47,7 +48,8 @@ public class AgentReader : IAgentReader
     {
         var manifests = Invoke.Command(AgentExecutablePath, $"detect-manifests {projectPath}", ".");
 
-        return manifests.TrimEnd('\n', '\r').Split("\n").ToList();
+        return manifests.IsEmpty() ? new List<string>() :
+            manifests.TrimEnd('\n', '\r').Split("\n").ToList();
     }
 
     public string ProcessManifest(string manifestPath, DateTime asOfDate)


### PR DESCRIPTION
Ensures that the list of manifest files is empty, as expected when no manifest files are found by the agent.