### PR TITLE
Agent bugs

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
@@ -30,6 +30,7 @@ public class GenerateBillOfMaterialsActivityTest
 
         // Act
         var analysisLocation = new Mock<IAnalysisLocation>();
+        analysisLocation.Setup(mock => mock.Path).Returns("/working/directory");
         var activity = new GenerateBillOfMaterialsActivity(agentExecutablePath, analysisLocation.Object, "/path/to/manifest");
         activity.Handle(eventEngine.Object);
 

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
@@ -25,7 +25,7 @@ public class GenerateBillOfMaterialsActivity : IApplicationActivity
         var agentReader = agentManager.GetReader(AgentExecutablePath);
 
         var asOfDate = DateTime.Now;
-        var pathToBillOfMaterials = agentReader.ProcessManifest(ManifestPath, asOfDate);
+        var pathToBillOfMaterials = agentReader.ProcessManifest(System.IO.Path.Combine(AnalysisLocation.Path, ManifestPath), asOfDate);
 
         eventClient.Fire(new BillOfMaterialsGeneratedEvent(AnalysisLocation, pathToBillOfMaterials));
     }

--- a/Corgibytes.Freshli.Cli/Services/AgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentReader.cs
@@ -55,7 +55,7 @@ public class AgentReader : IAgentReader
     public string ProcessManifest(string manifestPath, DateTime asOfDate)
     {
         var billOfMaterialsPath =
-            Invoke.Command(AgentExecutablePath, $"process-manifest {manifestPath} {asOfDate:s}", ".");
+            Invoke.Command(AgentExecutablePath, $"process-manifest {manifestPath} {asOfDate:o}", ".");
 
         return billOfMaterialsPath.TrimEnd('\n', '\n');
     }


### PR DESCRIPTION
Found two small bugs. One is that I forgot a DateTime format, the other one was that the working directory wasn't passed so we were asking the agent to run this:
```shell
/usr/local/bin/freshli-agent-java process-manifest pom.xml 2022-09-23T13:37:24Z
```

Which doesn't work because it can't locate `pom.xml`