### PR TITLE
Fixes deserialization of Configuration class in Newtonsoft.json

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -21,7 +21,6 @@ public class AgentReaderTest
         {
             "java/pom.xml",
             "java/protoc/pom.xml",
-            "protoc-artifacts/pom.xml",
             "ruby/pom.xml"
         };
         Assert.Equal(expectedManifests, actualManifests);

--- a/Corgibytes.Freshli.Cli/Functionality/Configuration.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Configuration.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Newtonsoft.Json;
 
 namespace Corgibytes.Freshli.Cli.Functionality;
 
@@ -8,6 +9,13 @@ public class Configuration : IConfiguration
     {
         GitPath = "git";
         CacheDir = Path.Combine(environment.HomeDirectory, ".freshli");
+    }
+
+    [JsonConstructor]
+    public Configuration(string gitPath, string cacheDir)
+    {
+        GitPath = gitPath;
+        CacheDir = cacheDir;
     }
 
     public string GitPath { get; set; }


### PR DESCRIPTION
For the configuration object to be deserialized correctly in AnalysisLocation there needs to be a constructor that will set GitPath and CacheDir from the serialized data.  Because environment is not saved in the class it cannot be used to deserialize the object.