### PR TITLE
Remove uploading the NuGet package uploading to GitHub as we no longer have that

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
             --token ${{ secrets.GITHUB_TOKEN }} \
             --targetDirectory /home/runner/work/freshli-cli/freshli-cli \
             --tagName 'v${{ steps.gitversion.outputs.majorMinorPatch }}' \
-            --assets ${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-win-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-linux-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-osx-x64.zip,${{ env.NUGET_PACKAGE_PATH }}
+            --assets ${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-win-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-linux-x64.zip,${{ env.BUILD_ARTIFACTS_FOLDER }}/freshli-cli-${{ steps.gitversion.outputs.majorMinorPatch }}-osx-x64.zip
 
       # Push all versions to GitHub packages.  This includes alpha version, in the main branch, and beta
       # versions in the release branch.


### PR DESCRIPTION
Fixes broken main branch.
![image](https://user-images.githubusercontent.com/7047894/193240572-80395f96-6bcc-4d79-b8b3-5a00df8c0a20.png)

Related to this change: https://github.com/corgibytes/freshli-cli/pull/292