### PR TITLE
Start x workers

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/CommandOptions/AnalyzeCommandOptionsTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/CommandOptions/AnalyzeCommandOptionsTest.cs
@@ -12,7 +12,6 @@ namespace Corgibytes.Freshli.Cli.Test.CommandOptions;
 public class AnalyzeCommandOptionsTest : FreshliTest
 {
     private const string DefaultGitPath = "git";
-    private const int DefaultWorkerCount = 0;
     private const string DefaultHistoryInterval = "1m";
     private const bool DefaultCommitHistory = false;
     private const bool DefaultLatestOnly = false;
@@ -27,44 +26,34 @@ public class AnalyzeCommandOptionsTest : FreshliTest
             // If passing no arguments, the default git path should be 'git'
             new object?[]
             {
-                new[] { "analyze" }, "git", null, DefaultCommitHistory, DefaultHistoryInterval, DefaultWorkerCount,
-                DefaultLatestOnly
+                new[] { "analyze" }, "git", null, DefaultCommitHistory, DefaultHistoryInterval, DefaultLatestOnly
             },
             // Specific git path expected
             new object?[]
             {
                 new[] { "analyze", "--git-path", "/usr/bin/local/git" }, "/usr/bin/local/git", null,
-                DefaultCommitHistory, DefaultHistoryInterval, DefaultWorkerCount, DefaultLatestOnly
+                DefaultCommitHistory, DefaultHistoryInterval, DefaultLatestOnly
             },
             // Specific branch expected
             new object?[]
             {
                 new[] { "analyze", "--branch", "feature-fix-final.2.0" }, DefaultGitPath, "feature-fix-final.2.0",
-                DefaultCommitHistory, DefaultHistoryInterval, DefaultWorkerCount, DefaultLatestOnly
+                DefaultCommitHistory, DefaultHistoryInterval, DefaultLatestOnly
             },
             // Entire commit history expected
             new object?[]
             {
-                new[] { "analyze", "--commit-history" }, DefaultGitPath, null, true, DefaultHistoryInterval,
-                DefaultWorkerCount, DefaultLatestOnly
+                new[] { "analyze", "--commit-history" }, DefaultGitPath, null, true, DefaultHistoryInterval, DefaultLatestOnly
             },
             // Three yearly history interval expected
             new object?[]
             {
-                new[] { "analyze", "--history-interval", "3y" }, DefaultGitPath, null, DefaultCommitHistory, "3y",
-                DefaultWorkerCount, DefaultLatestOnly
-            },
-            // 24 workers expected
-            new object?[]
-            {
-                new[] { "analyze", "--workers", "24" }, DefaultGitPath, null, DefaultCommitHistory,
-                DefaultHistoryInterval, 24, DefaultLatestOnly
+                new[] { "analyze", "--history-interval", "3y" }, DefaultGitPath, null, DefaultCommitHistory, "3y", DefaultLatestOnly
             },
             // Latest only
             new object?[]
             {
-                new[] { "analyze", "--latest-only" }, DefaultGitPath, null, DefaultCommitHistory,
-                DefaultHistoryInterval, DefaultWorkerCount, true
+                new[] { "analyze", "--latest-only" }, DefaultGitPath, null, DefaultCommitHistory, DefaultHistoryInterval, true
             }
         };
 
@@ -72,7 +61,7 @@ public class AnalyzeCommandOptionsTest : FreshliTest
     [MemberData(nameof(AnalyzeOptionsArgs))]
     public void Send_Args_ReturnsAnalyzeOptions(
         string[] args, string expectedGitPath, string? expectedBranch, bool expectedCommitHistory,
-        string expectedHistoryInterval, int expectedWorkers, bool expectedLatestOnly
+        string expectedHistoryInterval, bool expectedLatestOnly
     )
     {
         var builder = Program.CreateCommandLineBuilder();
@@ -94,9 +83,6 @@ public class AnalyzeCommandOptionsTest : FreshliTest
 
         var historyInterval = result.GetOptionValueByName<string>("history-interval");
         historyInterval.Should().NotBeEmpty().And.Be(expectedHistoryInterval);
-
-        var workers = result.GetOptionValueByName<int>("workers");
-        workers.Should().Be(expectedWorkers);
 
         var latestOnly = result.GetOptionValueByName<bool>("latest-only");
         latestOnly.Should().Be(expectedLatestOnly);

--- a/Corgibytes.Freshli.Cli.Test/Commands/MainCommandTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Commands/MainCommandTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.CommandLine;
 using Corgibytes.Freshli.Cli.Commands;
 using Corgibytes.Freshli.Cli.Functionality;
@@ -25,11 +26,24 @@ public class MainCommandTest : FreshliTest
     }
 
     [Theory]
-    [InlineData("--cache-dir")]
-    public void Verify_cache_dir_option_configuration(string alias)
+    [MemberData(nameof(OptionsData))]
+    public void VerifyOptions(string alias, ArgumentArity arity)
     {
         var configuration = new Mock<IConfiguration>();
         var mainCommand = new MainCommand(configuration.Object);
-        mainCommand.VerifyAlias(alias, ArgumentArity.ExactlyOne, false);
+        mainCommand.VerifyAlias(alias, arity, false);
     }
+
+    public static IEnumerable<object?[]> OptionsData() =>
+        new List<object?[]>
+        {
+            new object?[]
+            {
+                "--workers", ArgumentArity.ZeroOrOne
+            },
+            new object?[]
+            {
+                "--cache-dir", ArgumentArity.ExactlyOne
+            }
+        };
 }

--- a/Corgibytes.Freshli.Cli/Commands/AnalyzeCommand.cs
+++ b/Corgibytes.Freshli.Cli/Commands/AnalyzeCommand.cs
@@ -58,14 +58,6 @@ public class AnalyzeCommand : RunnableCommand<AnalyzeCommand, AnalyzeCommandOpti
         });
         AddOption(historyInterval);
 
-        var workers = new Option<int>("--workers",
-            "The number of worker processes that should be running at any given time. This defaults to twice the number of CPU cores.")
-        {
-            AllowMultipleArgumentsPerToken = false,
-            Arity = ArgumentArity.ZeroOrOne
-        };
-        AddOption(workers);
-
         var latestOnly = new Option<bool>("--latest-only",
             "When this is set, analyze will not walk back in history, and overwrites the options --commit-history, --history-interval")
         {

--- a/Corgibytes.Freshli.Cli/Commands/MainCommand.cs
+++ b/Corgibytes.Freshli.Cli/Commands/MainCommand.cs
@@ -22,6 +22,14 @@ public class MainCommand : RootCommand
         var logFileOption = new Option<string>("--logfile", "file for logs instead of logging to console");
         AddOption(logFileOption);
 
+        var workers = new Option<int>("--workers",
+            "The number of worker processes that should be running at any given time. This defaults to twice the number of CPU cores.")
+        {
+            AllowMultipleArgumentsPerToken = false,
+            Arity = ArgumentArity.ZeroOrOne
+        };
+        AddOption(workers);
+
         // Add commands here!
         Add(new ScanCommand());
         Add(new CacheCommand());

--- a/features/analyze.feature
+++ b/features/analyze.feature
@@ -115,7 +115,7 @@ Feature: analyze
 
     Scenario: Run the analysis, start with 6 workers.
         Given a directory named "~/.freshli" does not exist
-        When I run `freshli analyze --workers=6 https://github.com/corgibytes/freshli-fixture-java-test`
+        When I run `freshli --workers=6 analyze https://github.com/corgibytes/freshli-fixture-java-test`
         Then the directory named "~/.freshli" should exist
         And a file named "~/.freshli/freshli.db" should exist
         And we can open a SQLite connection to "~/.freshli/freshli.db"


### PR DESCRIPTION
Fixes #232 

I decided to move the `--workers` from the `AnalyzeCommand` to the `MainCommand` because otherwise this check will fail when running a command that's not the analyze command:
```csharp
var workerCount = context.ParseResult.GetOptionValueByName<int>("workers");
```

It fails because the workers option doesn't exist at all. An alternative would be to catch the exception I guess but I found this way nicer. Maybe there's another way I'm missing? 

The statistics we have don't contain a worker count so I hope this screenshot will suffice. 
![image](https://user-images.githubusercontent.com/7047894/193868150-6df397c3-f93d-4aed-84b3-a72aa688f3e5.png)
