### PR TITLE
Upgrade Microsoft extensions together

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -23,13 +23,13 @@
     <PackageReference Include="Hangfire.Core" Version="1.7.31" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
     <PackageReference Include="MediatR" Version="11.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-rc.1.22426.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-rc.2.22472.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0-rc.1.22426.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0-rc.1.22426.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0-rc.1.22426.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0-rc.2.22472.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0-rc.2.22472.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="NamedServices.Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="NLog" Version="5.0.4" />


### PR DESCRIPTION
This PR combines these PRs:
https://github.com/corgibytes/freshli-cli/pull/335
https://github.com/corgibytes/freshli-cli/pull/333
https://github.com/corgibytes/freshli-cli/pull/331
https://github.com/corgibytes/freshli-cli/pull/330

Some of them need to be upgraded together otherwise we'll get this error:
```
/home/runner/work/freshli-cli/freshli-cli/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj : error NU1605: Detected package downgrade: Microsoft.Extensions.Hosting.Abstractions from 7.0.0-rc.2.22472.3 to 7.0.0-rc.1.22426.10. Reference the package directly from the project to select a different version.  [/home/runner/work/freshli-cli/freshli-cli/freshli-cli.sln]
```
