### PR TITLE
Fixes expected path in failing .NET test

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -35,9 +35,9 @@ public class AgentReaderTest
         SetupDirectory(out var repositoryLocation, out var reader, out var checkoutDirectory);
 
         // java/pom.xml is detected by detect manifest, see also DetectManifestsUsingProtobuf()
-        var billOfMaterialsPath = reader.ProcessManifest(repositoryLocation + "/java/pom.xml", DateTime.Now);
+        var billOfMaterialsPath = reader.ProcessManifest(Path.Combine(repositoryLocation, "java", "pom.xml"), DateTime.Now);
 
-        Assert.Equal("/tmp/repositories/protobuf/java/target/bom.json", billOfMaterialsPath);
+        Assert.Equal(Path.Combine(repositoryLocation, "java", "target", "bom.json"), billOfMaterialsPath);
 
         // delete cloned files
         checkoutDirectory.Delete(true);


### PR DESCRIPTION
This fixes a failure on the `main` branch when running `dotnet test`.