### PR TITLE
Limits `process-manifests` for a directory

### DIFF
--- a/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Corgibytes.Freshli.Cli.DataModel;
@@ -54,7 +55,7 @@ public class CacheManager : ICacheManager
         return true;
     }
 
-    public DirectoryInfo GetDirectoryInCache(string[] directoryStructure)
+    public DirectoryInfo GetDirectoryInCache(params string[] directoryStructure)
     {
         var cacheDir = new DirectoryInfo(_configuration.CacheDir);
         Prepare();
@@ -80,6 +81,18 @@ public class CacheManager : ICacheManager
         }
 
         return focus;
+    }
+
+    public string StoreBomInCache(string bomFilePath, Guid analysisId, DateTimeOffset asOfDateTime)
+    {
+        var bomFileInfo = new FileInfo(bomFilePath);
+
+        var bomCacheDirInfo = GetDirectoryInCache("boms", analysisId.ToString(), asOfDateTime.ToString("u"));
+        var cachedBomFilePath = Path.Combine(bomCacheDirInfo.FullName, bomFileInfo.Name);
+
+        File.Copy(bomFilePath, cachedBomFilePath);
+
+        return cachedBomFilePath;
     }
 
     public bool Destroy()

--- a/Corgibytes.Freshli.Cli/Functionality/ICacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/ICacheManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace Corgibytes.Freshli.Cli.Functionality;
@@ -7,7 +8,9 @@ public interface ICacheManager
     public bool ValidateCacheDirectory();
     public bool Prepare();
     public bool Destroy();
-    public DirectoryInfo GetDirectoryInCache(string[] directoryStructure);
+    public DirectoryInfo GetDirectoryInCache(params string[] directoryStructure);
+
+    public string StoreBomInCache(string pathToBom, Guid analysisId, DateTimeOffset asOfDateTime);
 
     public ICacheDb GetCacheDb();
 }

--- a/Corgibytes.Freshli.Cli/Services/AgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentReader.cs
@@ -57,7 +57,7 @@ public class AgentReader : IAgentReader
         return manifests.IsEmpty() ? new List<string>() : manifests.TrimEnd('\n', '\r').Split("\n").ToList();
     }
 
-    public string ProcessManifest(string manifestPath, DateTime asOfDateTime)
+    public string ProcessManifest(string manifestPath, DateTimeOffset asOfDateTime)
     {
         var billOfMaterialsPath =
             _invoke.Command(AgentExecutablePath, $"process-manifest {manifestPath} {asOfDateTime:o}", ".");

--- a/Corgibytes.Freshli.Cli/Services/IAgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/IAgentReader.cs
@@ -10,5 +10,5 @@ public interface IAgentReader
     public string AgentExecutablePath { get; }
     public List<Package> RetrieveReleaseHistory(PackageURL packageUrl);
     public List<string> DetectManifests(string projectPath);
-    public string ProcessManifest(string manifestPath, DateTime asOfDateTime);
+    public string ProcessManifest(string manifestPath, DateTimeOffset asOfDateTime);
 }


### PR DESCRIPTION
Fixes #361.

* Also moves the generated bom to a cache location so that it can be accessed by future activities without any worries
* Also discovered that `DateTime` was being used instead of `DateTimeOffset` when triggering the `process-manifest` command
* Also discovered that `DateTime.Now` was being used instead of the "as of" time from the cached history point