### PR TITLE
Update NLog extensions to latest version

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="NamedServices.Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="NLog" Version="5.0.5" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
-    <PackageReference Include="NLog.Extensions.Hosting" Version="5.0.4" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.0.4" />
+    <PackageReference Include="NLog.Extensions.Hosting" Version="5.1.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.1.0" />
     <PackageReference Include="packageurl-dotnet" Version="1.1.0" />
     <PackageReference Include="ServiceStack.Text" Version="6.4.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
This PR updates both NLog extensions at the same time. A replacement for these two PRs:
https://github.com/corgibytes/freshli-cli/pull/374
https://github.com/corgibytes/freshli-cli/pull/375