### PR TITLE
Fix failing analyze feature tests

### DIFF
--- a/features/analyze.feature
+++ b/features/analyze.feature
@@ -168,9 +168,8 @@ Feature: analyze
 
 
     Scenario: Run the analysis for a local directory
-        When I run `git clone https://github.com/corgibytes/freshli-fixture-java-test freshli-fixture-java-test`
-        Then the directory named "~/freshli-fixture-java-test" should exist
-        When I run `freshli --loglevel Debug analyze --history-interval=1y freshli-fixture-java-test`
+        When I run `git clone https://github.com/corgibytes/freshli-fixture-java-test /tmp/freshli-fixture-java-test`
+        When I run `freshli --loglevel Debug analyze --history-interval=1y /tmp/freshli-fixture-java-test`
         Then the "~/.freshli/freshli.db" contains history stop point at "2022-01-01 00:00:00" "7601fe07ea76d9ce8c9d5332db237d71e236ef4a"
         And the "~/.freshli/freshli.db" contains history stop point at "2021-01-01 00:00:00" "054452d2a28e0b1717c8e8002532a8e572abe66b"
         And the "~/.freshli/freshli.db" contains history stop point at "2020-01-01 00:00:00" "f58c3f8773da4ea4f01d819b842e384b3a343d40"


### PR DESCRIPTION
Fixes #359
@mscottford I think this fix, and the fix introduced here https://github.com/corgibytes/freshli-cli/pull/372
Are cases where the suite is actually failing. If I run the tests locally, separately, they don't fail. If I run them all at once the first two of analyze.feature fail. Separating the realistic scenario into a different file only causes that one to fail. 

So I think for fixing the CI on the main branch we have to look at what you suggested in Slack to get GitHub actions running on a bigger computer.