### PR TITLE
Fix/bootstrap m2 directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,22 +67,22 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: "[Build, Docker] - Set up QEMU"
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@v2
 
       - name: "[Build, Docker] - Set up Docker Buildx"
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-buildx-action@v2
 
       - name: "[Build, Docker] - Login to DockerHub"
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "[Build, Docker] - Build and push"
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,18 @@ ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 RUN mkdir -p $MAVEN_CONFIG
 
+# Bootstrap contents of .m2 directory
+RUN mkdir /root/bootstrap
+RUN echo "<project> \
+    <groupId>com.corgibytes</groupId> \
+    <artifactId>freshli-java-bootstrap</artifactId> \
+    <version>1.0</version> \
+    <modelVersion>4.0.0</modelVersion> \
+</project>" > /root/bootstrap/pom.xml
+RUN cd /root/bootstrap && \
+    mvn org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom && \
+    mvn com.corgibytes:versions-maven-plugin:resolve-ranges-historical
+
 # Copy `freshli` executable from the `dotnet_build` image
 RUN mkdir -p /usr/local/share/freshli
 COPY --from=dotnet_build /app/freshli/exe/ /usr/local/share/freshli/


### PR DESCRIPTION
* Updates CI so that it only builds and publishes a docker container image if the commit has a git tag that starts with `v`, such as `v0.5.2`.
* Updates the docker container build so that it pre-populates the contents of the `/root/.m2` directory with the dependencies that are needed the first time that the plugins `org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom` and `com.corgibytes:versions-maven-plugin:resolve-ranges-historical` are run. This fixes #388.