### PR TITLE
Prevent dependabot builds from attempting to publish coverage data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: "[Test] - Send Code Coverage Data to Code Climate"
         uses: paambaati/codeclimate-action@v3.2.0
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
When dependabot initiates a build, GitHub Actions prevents it from accessing any secrets. The action that publishes the results needs access to a value that's stored in the secrets, but the action fails because the value is just blank. This change disables the attempt to send the data when a build in initiated by dependabot.