### PR TITLE
Adds ExecutableFinder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,6 @@ jobs:
           ruby-version: 3.1 # Not needed with a .ruby-version file
           bundler-cache: true
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
       - name: "[Test] - Behavior Acceptance Tests"
         run: |
           bundle exec cucumber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
           ruby-version: 3.1 # Not needed with a .ruby-version file
           bundler-cache: true
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
       - name: "[Test] - Behavior Acceptance Tests"
         run: |
           bundle exec cucumber

--- a/Corgibytes.Freshli.Cli.Test/Functionality/AgentsDetectorTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/AgentsDetectorTest.cs
@@ -10,43 +10,57 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality;
 public class AgentsDetectorTest
 {
     [Fact]
-    public void TestingAgentsDetect()
+    public void TestingAgentsDetectWithMacAndLinuxPaths()
     {
-        var agentsDetector = new AgentsDetector(new MockEnvironment());
+        var executableFinder = new Mock<IExecutableFinder>();
+        executableFinder
+            .Setup(mock => mock.GetExecutables())
+            .Returns(new List<string>
+            {
+                "/usr/bin/freshli-agent-java",
+                "/usr/local/bin/freshli-agent-dotnet",
+                "/home/user/bin/utility"
+            });
+
+        var environment = new Mock<IEnvironment>();
+        environment
+            .Setup(mock => mock.PathSeparator)
+            .Returns("/");
+
+        var agentsDetector = new AgentsDetector(executableFinder.Object, environment.Object);
         var expectedResults = new List<string>
         {
-            "/usr/local/bin/freshli-agent-java",
-            "/usr/local/bin/freshli-agent-javascript",
-            "/usr/local/agents/bin/freshli-agent-csharp",
-            "/home/freshli-user/bin/agents/freshli-agent-ruby"
+            "/usr/bin/freshli-agent-java",
+            "/usr/local/bin/freshli-agent-dotnet"
         };
         var results = agentsDetector.Detect();
         Assert.Equal(expectedResults, results);
     }
 
     [Fact]
-    public void DetectHandlesDuplicateAgentNames()
+    public void TestingAgentsDetectWithWindowsPaths()
     {
-        var environment = new Mock<IEnvironment>();
-
-        environment.Setup(mock => mock.DirectoriesInSearchPath).Returns(
-            new List<string>
+        var executableFinder = new Mock<IExecutableFinder>();
+        executableFinder
+            .Setup(mock => mock.GetExecutables())
+            .Returns(new List<string>
             {
-                "/usr/local/bin",
-                "/bin"
-            }
-        );
+                "C:\\Agents\\freshli-agent-java.bat",
+                "D:\\Agents\\dotnet\\bin\\freshli-agent-dotnet.exe",
+                "E:\\Utilities\\bin\\utility.com"
+            });
 
-        // Intentionally include the same file name in different directories
-        environment.Setup(mock => mock.GetListOfFiles("/bin")).Returns(new List<string?> { "freshli-agent-java" });
-        environment.Setup(mock => mock.GetListOfFiles("/usr/local/bin"))
-            .Returns(new List<string?> { "freshli-agent-java" });
+        var environment = new Mock<IEnvironment>();
+        environment
+            .Setup(mock => mock.PathSeparator)
+            .Returns("\\");
 
-        var agentsDetector = new AgentsDetector(environment.Object);
-
-        // The only `freshli-agent-java` command that should be included in the output is the directory that comes
-        // first in the list of directories in the search path.
-        var expectedResults = new List<string> { "/usr/local/bin/freshli-agent-java" };
+        var agentsDetector = new AgentsDetector(executableFinder.Object, environment.Object);
+        var expectedResults = new List<string>
+        {
+            "C:\\Agents\\freshli-agent-java.bat",
+            "D:\\Agents\\dotnet\\bin\\freshli-agent-dotnet.exe"
+        };
         var results = agentsDetector.Detect();
         Assert.Equal(expectedResults, results);
     }

--- a/Corgibytes.Freshli.Cli.Test/Functionality/EnvironmentTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/EnvironmentTest.cs
@@ -20,7 +20,7 @@ public class EnvironmentTest
                 "Fixtures", "EnvironmentTest"
             )
         );
-        var expectedResults = new List<string?>
+        var expectedResults = new List<string>
         {
             "OtherSampleFile.txt",
             "SampleFile.txt"

--- a/Corgibytes.Freshli.Cli.Test/Functionality/ExecutableFinderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/ExecutableFinderTest.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using Corgibytes.Freshli.Cli.Functionality;
+using Moq;
+using Xunit;
+
+namespace Corgibytes.Freshli.Cli.Test.Functionality;
+
+[UnitTest]
+public class ExecutableFinderTest
+{
+    [Fact]
+    public void FindHonorsExecutableStatusOnMacAndLinuxAndCorrectlyHandlesDuplicates()
+    {
+        var environment = new Mock<IEnvironment>();
+        environment.Setup(mock => mock.IsWindows).Returns(false);
+        environment.Setup(mock => mock.PathSeparator).Returns("/");
+
+        environment.Setup(mock => mock.HomeDirectory).Returns("/home/user");
+        environment
+            .Setup(mock => mock.DirectoriesInSearchPath)
+            .Returns(new List<string> { "/usr/bin", "/usr/local/bin", "~/bin" });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("/usr/bin"))
+            .Returns(new List<string>
+            {
+                "freshli-agent-java",
+                "freshli-agent-java.bat",
+                "freshli-agent-dotnet",
+                "freshli-agent-dotnet.bat",
+                "other-one"
+            });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("/usr/local/bin"))
+            .Returns(new List<string>
+            {
+                "freshli-agent-java",
+                "freshli-agent-java.bat",
+                "freshli-agent-ruby",
+                "freshli-agent-ruby.bat",
+                "other-two"
+            });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("/home/user/bin"))
+            .Returns(new List<string>
+            {
+                "utility"
+            });
+
+        var executableStats = new Dictionary<string, bool>
+        {
+            { "/usr/bin/freshli-agent-java", true },
+            { "/usr/bin/freshli-agent-java.bat", false },
+            { "/usr/bin/freshli-agent-dotnet", true },
+            { "/usr/bin/freshli-agent-dotnet.bat", false },
+            { "/usr/bin/other-one", false },
+            { "/usr/local/bin/freshli-agent-java", true },
+            { "/usr/local/bin/freshli-agent-java.bat", false },
+            { "/usr/local/bin/freshli-agent-ruby", true },
+            { "/usr/local/bin/freshli-agent-ruby.bat", false },
+            { "/usr/local/bin/other-two", false },
+            { "/home/user/bin/utility", true }
+        };
+
+        foreach (var entry in executableStats)
+        {
+            environment
+                .Setup(mock => mock.HasExecutableBit(entry.Key))
+                .Returns(entry.Value);
+        }
+
+        var expectedExecutables = new List<string>
+        {
+            "/home/user/bin/utility",
+            "/usr/bin/freshli-agent-dotnet",
+            "/usr/bin/freshli-agent-java",
+            "/usr/local/bin/freshli-agent-ruby"
+        };
+
+        var finder = new ExecutableFinder(environment.Object);
+
+        var actualExecutables = finder.GetExecutables();
+
+        Assert.Equal(expectedExecutables, actualExecutables);
+    }
+
+    [Fact]
+    public void FindHonorsExecutableStatusOnWindowsAndCorrectlyHandlesDuplicates()
+    {
+        var environment = new Mock<IEnvironment>();
+        environment.Setup(mock => mock.IsWindows).Returns(true);
+        environment.Setup(mock => mock.PathSeparator).Returns("\\");
+
+        environment.Setup(mock => mock.HomeDirectory).Returns("C:\\Users\\user");
+        environment
+            .Setup(mock => mock.DirectoriesInSearchPath)
+            .Returns(new List<string> { "C:\\Agents", "D:\\Agents", "~\\bin" });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("C:\\Agents"))
+            .Returns(new List<string>
+            {
+                "freshli-agent-java",
+                "freshli-agent-java.bat",
+                "freshli-agent-dotnet",
+                "freshli-agent-dotnet.com",
+                "other-one"
+            });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("D:\\Agents"))
+            .Returns(new List<string>
+            {
+                "freshli-agent-java",
+                "freshli-agent-java.bat",
+                "freshli-agent-ruby",
+                "freshli-agent-ruby.exe",
+                "ALLCAPS.BAT",
+                "other-two"
+            });
+
+        environment
+            .Setup(mock => mock.GetListOfFiles("C:\\Users\\user\\bin"))
+            .Returns(new List<string> { "utility.bat" });
+
+        environment
+            .Setup(mock => mock.WindowsExecutableExtensions)
+            .Returns(new List<string>
+            {
+                "exe",
+                "bat",
+                "com"
+            });
+
+        var expectedExecutables = new List<string>
+        {
+            "C:\\Agents\\freshli-agent-dotnet.com",
+            "C:\\Agents\\freshli-agent-java.bat",
+            "C:\\Users\\user\\bin\\utility.bat",
+            "D:\\Agents\\ALLCAPS.BAT",
+            "D:\\Agents\\freshli-agent-ruby.exe"
+        };
+
+        var finder = new ExecutableFinder(environment.Object);
+
+        var actualExecutables = finder.GetExecutables();
+
+        Assert.Equal(expectedExecutables, actualExecutables);
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Functionality/MockEnvironment.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/MockEnvironment.cs
@@ -6,20 +6,24 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality;
 
 public class MockEnvironment : IEnvironment
 {
-    public IList<string?> GetListOfFiles(string directory) => directory switch
+    public IList<string> WindowsExecutableExtensions => new List<string>();
+    public string PathSeparator => "/";
+
+    public IList<string> GetListOfFiles(string directory) => directory switch
     {
-        "/usr/local/bin" => new List<string?>
+        "/usr/local/bin" => new List<string>
         {
             "freshli-agent-java",
             "freshli-agent-javascript",
             "bash"
         },
-        "/usr/local/agents/bin" => new List<string?> { "freshli-agent-csharp" },
-        "/home/freshli-user/bin/agents" => new List<string?> { "freshli-agent-ruby" },
+        "/usr/local/agents/bin" => new List<string> { "freshli-agent-csharp" },
+        "/home/freshli-user/bin/agents" => new List<string> { "freshli-agent-ruby" },
         _ => throw new ArgumentException("Unrecognized Directory")
     };
 
     public string? GetVariable(string variableName) => null;
+    public bool HasExecutableBit(string fileName) => true;
 
     public IList<string> DirectoriesInSearchPath => new List<string>
     {
@@ -29,4 +33,5 @@ public class MockEnvironment : IEnvironment
     };
 
     public string HomeDirectory => "/home/freshli-user";
+    public bool IsWindows => false;
 }

--- a/Corgibytes.Freshli.Cli/Commands/AgentsDetector.cs
+++ b/Corgibytes.Freshli.Cli/Commands/AgentsDetector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Corgibytes.Freshli.Cli.Functionality;
 

--- a/Corgibytes.Freshli.Cli/Commands/AgentsDetector.cs
+++ b/Corgibytes.Freshli.Cli/Commands/AgentsDetector.cs
@@ -7,42 +7,20 @@ namespace Corgibytes.Freshli.Cli.Commands;
 
 public class AgentsDetector : IAgentsDetector
 {
+    private readonly IExecutableFinder _executableFinder;
     private readonly IEnvironment _environment;
 
-    public AgentsDetector(IEnvironment environment) => _environment = environment;
+    public AgentsDetector(IExecutableFinder executableFinder, IEnvironment environment)
+    {
+        _executableFinder = executableFinder;
+        _environment = environment;
+    }
 
     public IList<string> Detect()
     {
-        var paths = _environment.DirectoriesInSearchPath;
-        var agents = new Dictionary<string, string>();
-        foreach (var path in paths)
-        {
-            var searchPath = path;
-            IList<string?> filesResults;
-            if (path.Contains("~/"))
-            {
-                var homePath = _environment.HomeDirectory;
-                homePath += Path.DirectorySeparatorChar;
-                searchPath = path.Replace("~/", homePath);
-                filesResults = _environment.GetListOfFiles(searchPath);
-            }
-            else
-            {
-                filesResults = _environment.GetListOfFiles(searchPath);
-            }
-
-            foreach (var file in filesResults)
-            {
-                if (file != null && Path.GetFileName(file).StartsWith("freshli-agent-"))
-                {
-                    if (!agents.ContainsKey(file))
-                    {
-                        agents.Add(file, Path.Combine(searchPath, file));
-                    }
-                }
-            }
-        }
-
-        return agents.Values.ToList();
+        return _executableFinder
+            .GetExecutables()
+            .Where(value => value.Split(_environment.PathSeparator).Last().StartsWith("freshli-agent-"))
+            .ToList();
     }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/Environment.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Environment.cs
@@ -34,9 +34,21 @@ public class Environment : IEnvironment
             return false;
         }
 
+        UnixFileMode mode;
+        try
+        {
 #pragma warning disable CA1416
-        var mode = File.GetUnixFileMode(fileName);
+            mode = File.GetUnixFileMode(fileName);
 #pragma warning restore CA1416
+        }
+        catch (FileNotFoundException)
+        {
+            // This happens when a symbolic link points to a file that
+            // doesn't exist, in that case, just assume that the file
+            // is not executable, so it doesn't get included in the
+            // results.
+            return false;
+        }
         return (
             mode & (
                 UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute

--- a/Corgibytes.Freshli.Cli/Functionality/Environment.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Environment.cs
@@ -1,29 +1,66 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Corgibytes.Freshli.Cli.Functionality;
 
 public class Environment : IEnvironment
 {
-    public IList<string?> GetListOfFiles(string directory)
+    public string PathSeparator => Path.DirectorySeparatorChar.ToString();
+
+    public IList<string> GetListOfFiles(string directory)
     {
         try
         {
-            var files = Directory.GetFiles(directory).Select(Path.GetFileName).ToList();
+            var files = Directory.GetFiles(directory)
+                .Select(value => Path.GetFileName(value) ?? throw new ArgumentNullException(nameof(value)))
+                .ToList();
             files.Sort();
             return files;
         }
         catch (DirectoryNotFoundException)
         {
-            return new List<string?>();
+            return new List<string>();
         }
     }
 
     public string? GetVariable(string variableName) => System.Environment.GetEnvironmentVariable(variableName);
+    public bool HasExecutableBit(string fileName)
+    {
+        if (IsWindows)
+        {
+            return false;
+        }
+
+#pragma warning disable CA1416
+        var mode = File.GetUnixFileMode(fileName);
+#pragma warning restore CA1416
+        return (
+            mode & (
+                UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute
+            )) != UnixFileMode.None;
+    }
 
     public IList<string> DirectoriesInSearchPath =>
         System.Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator).ToList();
 
     public string HomeDirectory => System.Environment.GetEnvironmentVariable("HOME")!;
+
+    public bool IsWindows
+    {
+        get
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+    }
+
+    public IList<string> WindowsExecutableExtensions
+    {
+        get
+        {
+            return GetVariable("PATHEXT")!.Split(Path.PathSeparator.ToString()).ToList();
+        }
+    }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/ExecutableFinder.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/ExecutableFinder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
 using ServiceStack;
 
@@ -22,7 +20,7 @@ public class ExecutableFinder : IExecutableFinder
         foreach (var path in paths)
         {
             var searchPath = path;
-            IList<string?> filesResults;
+            IList<string> filesResults;
             if (path.Contains("~" + _environment.PathSeparator))
             {
                 var homePath = _environment.HomeDirectory;

--- a/Corgibytes.Freshli.Cli/Functionality/ExecutableFinder.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/ExecutableFinder.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ServiceStack;
+
+namespace Corgibytes.Freshli.Cli.Functionality;
+
+public class ExecutableFinder : IExecutableFinder
+{
+    private readonly IEnvironment _environment;
+
+    public ExecutableFinder(IEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public IList<string> GetExecutables()
+    {
+        var paths = _environment.DirectoriesInSearchPath;
+        var executables = new Dictionary<string, string>();
+        foreach (var path in paths)
+        {
+            var searchPath = path;
+            IList<string?> filesResults;
+            if (path.Contains("~" + _environment.PathSeparator))
+            {
+                var homePath = _environment.HomeDirectory;
+                homePath += _environment.PathSeparator;
+                searchPath = path.Replace("~" + _environment.PathSeparator, homePath);
+                filesResults = _environment.GetListOfFiles(searchPath);
+            }
+            else
+            {
+                filesResults = _environment.GetListOfFiles(searchPath);
+            }
+
+            foreach (var file in filesResults)
+            {
+                var fullPath = $"{searchPath}{_environment.PathSeparator}{file}";
+                if (IsExecutable(fullPath))
+                {
+                    if (!executables.ContainsKey(file))
+                    {
+                        executables.Add(file, fullPath);
+                    }
+                }
+            }
+        }
+
+        var executablesList = executables.Values.ToList();
+        executablesList.Sort();
+        return executablesList;
+    }
+
+    private bool IsExecutable(string fileName)
+    {
+        if (!_environment.IsWindows)
+        {
+            return _environment.HasExecutableBit(fileName);
+        }
+
+        foreach (var extension in _environment.WindowsExecutableExtensions)
+        {
+            if (fileName.EndsWithIgnoreCase(extension))
+            {
+                return true;
+            }
+        }
+
+        return false;
+
+    }
+}
+

--- a/Corgibytes.Freshli.Cli/Functionality/IEnvironment.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/IEnvironment.cs
@@ -4,11 +4,15 @@ namespace Corgibytes.Freshli.Cli.Functionality;
 
 public interface IEnvironment
 {
-    public IList<string> DirectoriesInSearchPath { get; }
+    IList<string> DirectoriesInSearchPath { get; }
 
     public string HomeDirectory { get; }
+    bool IsWindows { get; }
+    IList<string> WindowsExecutableExtensions { get; }
+    string PathSeparator { get; }
 
-    public IList<string?> GetListOfFiles(string directory);
+    IList<string> GetListOfFiles(string directory);
 
-    public string? GetVariable(string variableName);
+    string? GetVariable(string variableName);
+    bool HasExecutableBit(string fileName);
 }

--- a/Corgibytes.Freshli.Cli/Functionality/IExecutableFinder.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/IExecutableFinder.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Corgibytes.Freshli.Cli.Functionality;
+
+public interface IExecutableFinder
+{
+    IList<string> GetExecutables();
+}

--- a/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
+++ b/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
@@ -32,6 +32,7 @@ public class FreshliServiceBuilder
     {
         Services.AddSingleton(Configuration);
         Services.AddSingleton<IEnvironment, Environment>();
+        Services.AddScoped<IExecutableFinder, ExecutableFinder>();
         Services.AddScoped<ICacheManager, CacheManager>();
         Services.AddScoped<IAgentManager, AgentManager>();
         Services.AddScoped<IHistoryIntervalParser, HistoryIntervalParser>();

--- a/features/agents.feature
+++ b/features/agents.feature
@@ -4,7 +4,7 @@ Feature: Agents
     One line of output is created for each language agent that is detected.
     Scenario: Displays all language agents
         Given the directory named "~/bin"
-        And an empty file named "~/bin/freshli-agent-test"
+        And an empty executable file named "~/bin/freshli-agent-test"
         And the directory named "~/bin" is prepended to the PATH environment variable
         When I run `freshli agents detect`
         Then the output should contain:

--- a/features/agents.feature
+++ b/features/agents.feature
@@ -21,6 +21,7 @@ Feature: Agents
         And the directory named "~/bin"
         And an empty executable file named "~/not-bin/freshli-agent-test"
         And a symbolic link from "~/not-bin/freshli-agent-test" to "~/bin/freshli-agent-test"
+        And a symbolic link from "~/not-bin/invalid-file" to "~/bin/invalid-file"
         And the directory named "~/bin" is prepended to the PATH environment variable
         When I run `freshli agents detect`
         Then the output should contain:

--- a/features/agents.feature
+++ b/features/agents.feature
@@ -15,3 +15,20 @@ Feature: Agents
         """
         /tmp/aruba/bin/freshli-agent-test
         """
+
+    Scenario: Correctly handles symbolic links in path
+        Given the directory named "~/not-bin"
+        And the directory named "~/bin"
+        And an empty executable file named "~/not-bin/freshli-agent-test"
+        And a symbolic link from "~/not-bin/freshli-agent-test" to "~/bin/freshli-agent-test"
+        And the directory named "~/bin" is prepended to the PATH environment variable
+        When I run `freshli agents detect`
+        Then the output should contain:
+        """
+        freshli-agent-test
+        """
+        And the output should contain:
+        """
+        /tmp/aruba/bin/freshli-agent-test
+        """
+

--- a/features/step_definitions/filesystem.rb
+++ b/features/step_definitions/filesystem.rb
@@ -13,6 +13,10 @@ Given('an empty executable file named {string}') do |filename|
   FileUtils.chmod('a=x', filename)
 end
 
+Given('a symbolic link from {string} to {string}') do |source, target|
+  FileUtils.ln_sf(resolve_path(source), resolve_path(target))
+end
+
 Given('I create a directory named {string}') do |dirname|
   dirname = resolve_path dirname
   Dir.mkdir dirname

--- a/features/step_definitions/filesystem.rb
+++ b/features/step_definitions/filesystem.rb
@@ -7,7 +7,7 @@ Given('a blank file named {string} exists') do |filename|
   FileUtils.touch filename
 end
 
-Given('a blank executable file name {string} exists') do |filename|
+Given('an empty executable file named {string}') do |filename|
   filename = resolve_path filename
   FileUtils.touch filename
   FileUtils.chmod('a=x', filename)

--- a/features/step_definitions/filesystem.rb
+++ b/features/step_definitions/filesystem.rb
@@ -7,6 +7,12 @@ Given('a blank file named {string} exists') do |filename|
   FileUtils.touch filename
 end
 
+Given('a blank executable file name {string} exists') do |filename|
+  filename = resolve_path filename
+  FileUtils.touch filename
+  FileUtils.chmod('a=x', filename)
+end
+
 Given('I create a directory named {string}') do |dirname|
   dirname = resolve_path dirname
   Dir.mkdir dirname


### PR DESCRIPTION
- On Windows uses PATHEXT environment variable to find executable files
- On Mac/Linux uses the executable bit to determine if a file is an executable
- Changes AgentDetector to use the new ExecutableFinder

Fixes #422.