### PR TITLE
Fix async tests

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/CommandRunners/AnalyzeRunnerTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/CommandRunners/AnalyzeRunnerTest.cs
@@ -53,7 +53,7 @@ public class AnalyzeRunnerTest
     }
 
     [Fact]
-    public async ValueTask RunIndicatesThatAnalysisIsComplete()
+    public async Task RunIndicatesThatAnalysisIsComplete()
     {
         var apiAnalysisId = Guid.NewGuid();
 
@@ -69,7 +69,7 @@ public class AnalyzeRunnerTest
     }
 
     [Fact]
-    public async ValueTask RunIndicatesThatAnalysisFailed()
+    public async Task RunIndicatesThatAnalysisFailed()
     {
         var apiAnalysisId = Guid.NewGuid();
 
@@ -86,7 +86,7 @@ public class AnalyzeRunnerTest
     }
 
     [Fact]
-    public async ValueTask RunIndicatesThatCouldNotCallApi()
+    public async Task RunIndicatesThatCouldNotCallApi()
     {
         var exitCode = await _analyzeRunner.Run(_options, _console.Object);
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Agents/DetectAgentsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Agents/DetectAgentsActivityTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Agents;
 public class DetectAgentsActivityTest
 {
     [Fact]
-    public async ValueTask VerifyItFiresAgentsDetectedEvent()
+    public async Task VerifyItFiresAgentsDetectedEvent()
     {
         var eventClient = new Mock<IApplicationEventEngine>();
         var agentsDetector = new Mock<IAgentsDetector>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AgentDetectedForDetectManifestEventTest.cs
@@ -11,7 +11,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class AgentDetectedForDetectManifestEventTest
 {
     [Fact]
-    public async ValueTask Handle()
+    public async Task Handle()
     {
         const string agentExecutablePath = "/path/to/agent";
         var analysisId = Guid.NewGuid();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AnalysisStartedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/AnalysisStartedEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class AnalysisStartedEventTest
 {
     [Fact]
-    public async ValueTask HandleDispatchesCreateAnalysisApiActivity()
+    public async Task HandleDispatchesCreateAnalysisApiActivity()
     {
         var eventClient = new Mock<IApplicationActivityEngine>();
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheDoesNotExistEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CacheDoesNotExistEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class CacheWasNotPreparedEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesPrepareCacheActivity()
+    public async Task CorrectlyDispatchesPrepareCacheActivity()
     {
         var serviceProvider = new Mock<IServiceProvider>();
         var cacheManager = new Mock<ICacheManager>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CachePreparedForAnalysisEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/CachePreparedForAnalysisEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class CachePreparedForAnalysisEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesRestartAnalysisActivity()
+    public async Task CorrectlyDispatchesRestartAnalysisActivity()
     {
         var serviceProvider = new Mock<IServiceProvider>();
         var configuration = new Mock<IConfiguration>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectAgentsForDetectManifestsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectAgentsForDetectManifestsActivityTest.cs
@@ -34,7 +34,7 @@ public class DetectAgentsForDetectManifestsActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItDispatchesAgentDetectedForDetectManifestEvent()
+    public async Task VerifyItDispatchesAgentDetectedForDetectManifestEvent()
     {
         var agentPaths = new List<string>
         {
@@ -65,7 +65,7 @@ public class DetectAgentsForDetectManifestsActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItDispatchesNoAgentsDetectedFailureEvent()
+    public async Task VerifyItDispatchesNoAgentsDetectedFailureEvent()
     {
         var agentPaths = new List<string>();
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
@@ -16,7 +16,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class DetectManifestsUsingAgentActivityTest
 {
     [Fact]
-    public async ValueTask Handle()
+    public async Task Handle()
     {
         const string localPath = "/path/to/repository";
         var agentReader = new Mock<IAgentReader>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ErrorEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ErrorEventTest.cs
@@ -10,7 +10,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class ErrorEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesLogAnalysisFailureActivity()
+    public async Task CorrectlyDispatchesLogAnalysisFailureActivity()
     {
         var errorEvent = new InvalidHistoryIntervalEvent { ErrorMessage = "Uh-oh!" };
         var engine = new Mock<IApplicationActivityEngine>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/LogAnalysisFailureActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/LogAnalysisFailureActivityTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class LogAnalysisFailureActivityTest
 {
     [Fact]
-    public async ValueTask VerifyItFiresAnalysisFailureLoggedEvent()
+    public async Task VerifyItFiresAnalysisFailureLoggedEvent()
     {
         var serviceProvider = new Mock<IServiceProvider>();
         var eventClient = new Mock<IApplicationEventEngine>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/ManifestDetectedEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Analysis;
 public class ManifestDetectedEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesGenerateBillOfMaterialsActivity()
+    public async Task CorrectlyDispatchesGenerateBillOfMaterialsActivity()
     {
         const string manifestPath = "/path/to/manifest";
         var engine = new Mock<IApplicationActivityEngine>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/PrepareCacheForAnalysisActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/PrepareCacheForAnalysisActivityTest.cs
@@ -42,7 +42,7 @@ public class PrepareCacheForAnalysisActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareSucceeds()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareSucceeds()
     {
         _cacheManager.Setup(mock => mock.Prepare()).ReturnsAsync(true);
 
@@ -58,7 +58,7 @@ public class PrepareCacheForAnalysisActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareFails()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareFails()
     {
         _cacheManager.Setup(mock => mock.Prepare()).ReturnsAsync(false);
 
@@ -68,7 +68,7 @@ public class PrepareCacheForAnalysisActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareThrowsAnException()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareThrowsAnException()
     {
         _cacheManager.Setup(mock => mock.Prepare()).Throws(new Exception("failure message"));
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/StartAnalysisActivityTestBase.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/StartAnalysisActivityTestBase.cs
@@ -32,7 +32,7 @@ public abstract class StartAnalysisActivityTestBase<TActivity, TErrorEvent> wher
     protected virtual Func<TErrorEvent, bool> EventValidator => _ => true;
 
     [Fact]
-    public async ValueTask HandlerFiresCacheWasNotPreparedEventWhenCacheIsMissing()
+    public async Task HandlerFiresCacheWasNotPreparedEventWhenCacheIsMissing()
     {
         _configuration.Setup(mock => mock.CacheDir).Returns("example");
         _intervalParser.Setup(mock => mock.IsValid("1m")).Returns(true);
@@ -47,7 +47,7 @@ public abstract class StartAnalysisActivityTestBase<TActivity, TErrorEvent> wher
     }
 
     [Fact]
-    public async ValueTask HandlerFiresAnalysisStartedEventWhenCacheIsPresent()
+    public async Task HandlerFiresAnalysisStartedEventWhenCacheIsPresent()
     {
         var analysisId = Guid.NewGuid();
 
@@ -70,7 +70,7 @@ public abstract class StartAnalysisActivityTestBase<TActivity, TErrorEvent> wher
     }
 
     [Fact]
-    public async ValueTask HandlerFiresInvalidHistoryIntervalEventWhenHistoryIntervalValueIsInvalid()
+    public async Task HandlerFiresInvalidHistoryIntervalEventWhenHistoryIntervalValueIsInvalid()
     {
         _configuration.Setup(mock => mock.CacheDir).Returns("example");
         _intervalParser.Setup(mock => mock.IsValid("1m")).Returns(false);

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
@@ -13,7 +13,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.BillOfMaterials;
 public class GenerateBillOfMaterialsActivityTest
 {
     [Fact]
-    public async ValueTask Handle()
+    public async Task Handle()
     {
         // Arrange
         var asOfDateTime = DateTimeOffset.Now;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Cache/DestroyCacheActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Cache/DestroyCacheActivityTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Cache;
 public class DestroyCacheActivityTest
 {
     [Fact]
-    public async ValueTask VerifyItFiresCacheDestroyedEvent()
+    public async Task VerifyItFiresCacheDestroyedEvent()
     {
         var cacheManager = new Mock<ICacheManager>();
         var serviceProvider = new Mock<IServiceProvider>();
@@ -32,7 +32,7 @@ public class DestroyCacheActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCacheDestroyFailedEvent()
+    public async Task VerifyItFiresCacheDestroyFailedEvent()
     {
         var cacheManager = new Mock<ICacheManager>();
         var serviceProvider = new Mock<IServiceProvider>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Cache/PrepareCacheActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Cache/PrepareCacheActivityTest.cs
@@ -28,7 +28,7 @@ public class PrepareCacheActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareReturnsTrue()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareReturnsTrue()
     {
         _cacheManager.Setup(mock => mock.Prepare()).ReturnsAsync(true);
 
@@ -38,7 +38,7 @@ public class PrepareCacheActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareReturnsFalse()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareReturnsFalse()
     {
         _cacheManager.Setup(mock => mock.Prepare()).ReturnsAsync(false);
 
@@ -48,7 +48,7 @@ public class PrepareCacheActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyItFiresCachePreparedEventWhenPrepareThrowsAnException()
+    public async Task VerifyItFiresCachePreparedEventWhenPrepareThrowsAnException()
     {
         _cacheManager.Setup(mock => mock.Prepare()).Throws(new Exception("failure message"));
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/CacheManagerTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/CacheManagerTest.cs
@@ -28,7 +28,7 @@ public class CacheManagerTest : IDisposable
     }
 
     [Fact]
-    public async ValueTask SavePersistsACachedAnalysisAndGeneratesAnId()
+    public async Task SavePersistsACachedAnalysisAndGeneratesAnId()
     {
         var cacheManager = new CacheManager(_configuration.Object);
         await cacheManager.Prepare();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/AnalysisApiCreatedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/AnalysisApiCreatedEventTest.cs
@@ -13,7 +13,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.FreshliWeb;
 public class AnalysisApiCreatedEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesCloneGitRepositoryActivity()
+    public async Task CorrectlyDispatchesCloneGitRepositoryActivity()
     {
         var startedEvent = new AnalysisApiCreatedEvent
         {
@@ -31,7 +31,7 @@ public class AnalysisApiCreatedEventTest
     }
 
     [Fact]
-    public async ValueTask CorrectlyDispatchesVerifyGitRepositoryInLocalDirectoryActivity()
+    public async Task CorrectlyDispatchesVerifyGitRepositoryInLocalDirectoryActivity()
     {
         var temporaryLocation = new DirectoryInfo(Path.Combine(Path.GetTempPath(), new Guid().ToString()));
         temporaryLocation.Create();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/ApiHistoryStopCreatedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/ApiHistoryStopCreatedEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.FreshliWeb;
 public class ApiHistoryStopCreatedEventTest
 {
     [Fact]
-    public async ValueTask HandleDispatchesCheckoutHistoryActivity()
+    public async Task HandleDispatchesCheckoutHistoryActivity()
     {
         var cachedAnalysisId = Guid.NewGuid();
         const int historyStopPointId = 29;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateAnalysisApiActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateAnalysisApiActivityTest.cs
@@ -19,7 +19,7 @@ public class CreateAnalysisApiActivityTest
         _eventEngine.Setup(mock => mock.ServiceProvider).Returns(_serviceProvider.Object);
 
     [Fact]
-    public async ValueTask HandleSendsRequest()
+    public async Task HandleSendsRequest()
     {
         const string url = "anything";
         const string branch = "anythingelse";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateApiHistoryStopActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateApiHistoryStopActivityTest.cs
@@ -13,7 +13,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.FreshliWeb;
 public class CreateApiHistoryStopActivityTest
 {
     [Fact]
-    public async ValueTask Handle()
+    public async Task Handle()
     {
         var cachedAnalysisId = Guid.NewGuid();
         var apiAnalysisId = Guid.NewGuid();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateApiPackageLibYearActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/CreateApiPackageLibYearActivityTest.cs
@@ -13,7 +13,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.FreshliWeb;
 public class CreateApiPackageLibYearActivityTest
 {
     [Fact]
-    public async ValueTask HandleCorrectlyCallsApiAndFiresApiPackageLibYearCreatedEvent()
+    public async Task HandleCorrectlyCallsApiAndFiresApiPackageLibYearCreatedEvent()
     {
         var analysisId = Guid.NewGuid();
         const int historyStopPointId = 12;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/UpdateAnalysisStatusActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/FreshliWeb/UpdateAnalysisStatusActivityTest.cs
@@ -11,7 +11,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.FreshliWeb;
 public class UpdateAnalysisStatusActivityTest
 {
     [Fact]
-    public async ValueTask HandleSendsSuccessStatusToApi()
+    public async Task HandleSendsSuccessStatusToApi()
     {
         var apiAnalysisId = Guid.NewGuid();
         const string status = "success";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/BillOfMaterialsGeneratedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/BillOfMaterialsGeneratedEventTest.cs
@@ -11,7 +11,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Git;
 public class BillOfMaterialsGeneratedEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesComputeLibYearActivity()
+    public async Task CorrectlyDispatchesComputeLibYearActivity()
     {
         var serviceProvider = new Mock<IServiceProvider>();
         const string pathToBom = "/path/to/bom";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/CloneGitRepositoryActivityTest.cs
@@ -56,7 +56,7 @@ public class CloneGitRepositoryActivityTest
         _cacheDb.Setup(mock => mock.RetrieveAnalysis(_analysisId)).ReturnsAsync(_cachedAnalysis);
 
     [Fact]
-    public async ValueTask HandlerFiresGitRepositoryClonedEventWhenAnalysisStarted()
+    public async Task HandlerFiresGitRepositoryClonedEventWhenAnalysisStarted()
     {
         SetupCachedAnalysis();
         SetupCloneOrPullUsingDefaults();
@@ -69,7 +69,7 @@ public class CloneGitRepositoryActivityTest
     }
 
     [Fact]
-    public async ValueTask HandlerFiresCloneGitRepositoryFailedEventWhenGitCloneFails()
+    public async Task HandlerFiresCloneGitRepositoryFailedEventWhenGitCloneFails()
     {
         SetupCachedAnalysis();
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/GitRepositoryClonedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/GitRepositoryClonedEventTest.cs
@@ -14,7 +14,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Git;
 public class GitRepositoryClonedEventTest
 {
     [Fact]
-    public async ValueTask CorrectlyDispatchesComputeHistoryActivity()
+    public async Task CorrectlyDispatchesComputeHistoryActivity()
     {
         const string gitPath = "test";
         const string cacheDir = "example";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/GitRepositoryInLocalDirectoryVerifiedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/GitRepositoryInLocalDirectoryVerifiedEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.Git;
 public class GitRepositoryInLocalDirectoryVerifiedEventTest
 {
     [Fact]
-    public async ValueTask VerifyItFiresComputeHistoryActivity()
+    public async Task VerifyItFiresComputeHistoryActivity()
     {
         var analysisId = Guid.NewGuid();
         var localDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/VerifyGitRepositoryInLocalDirectoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/VerifyGitRepositoryInLocalDirectoryActivityTest.cs
@@ -43,7 +43,7 @@ public class VerifyGitRepositoryInLocalDirectoryActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyHandlerFiresEvent()
+    public async Task VerifyHandlerFiresEvent()
     {
         var repositoryLocation = new DirectoryInfo(_repositoryLocation);
         repositoryLocation.Create();
@@ -76,7 +76,7 @@ public class VerifyGitRepositoryInLocalDirectoryActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyHandlerFiresFailureEventIfDirectoryDoesNotExist()
+    public async Task VerifyHandlerFiresFailureEventIfDirectoryDoesNotExist()
     {
         var activity = new VerifyGitRepositoryInLocalDirectoryActivity { AnalysisId = _analysisId };
         await activity.Handle(_eventEngine.Object);
@@ -87,7 +87,7 @@ public class VerifyGitRepositoryInLocalDirectoryActivityTest
     }
 
     [Fact]
-    public async ValueTask VerifyHandlerFiresFailureEventIfDirectoryIsNotGitInitialized()
+    public async Task VerifyHandlerFiresFailureEventIfDirectoryIsNotGitInitialized()
     {
         var repositoryLocation = new DirectoryInfo(_repositoryLocation);
         repositoryLocation.Create();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/History/CheckoutHistoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/History/CheckoutHistoryActivityTest.cs
@@ -14,7 +14,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.History;
 public class CheckoutHistoryActivityTest
 {
     [Fact]
-    public async ValueTask Handle()
+    public async Task Handle()
     {
         const string commitId = "abcdef1";
         const string gitExecutablePath = "/path/to/git";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
@@ -43,7 +43,7 @@ public class ComputeHistoryActivityTest
     private Configuration Configuration { get; }
 
     [Fact]
-    public async ValueTask FiresHistoryIntervalStopFoundEvents()
+    public async Task FiresHistoryIntervalStopFoundEvents()
     {
         SetupCachedAnalysis("https://lorem-ipsum.com", "main", "1m", CommitHistory.AtInterval,
             RevisionHistoryMode.AllRevisions);
@@ -75,7 +75,7 @@ public class ComputeHistoryActivityTest
     }
 
     [Fact]
-    public async ValueTask FiresHistoryIntervalStopFoundEventsForComputeHistory()
+    public async Task FiresHistoryIntervalStopFoundEventsForComputeHistory()
     {
         SetupCachedAnalysis("https://lorem-ipsum.com", "main", "1m", CommitHistory.Full,
             RevisionHistoryMode.AllRevisions);
@@ -103,7 +103,7 @@ public class ComputeHistoryActivityTest
     }
 
     [Fact]
-    public async ValueTask FiresHistoryIntervalStopFoundEventsForLatestOnly()
+    public async Task FiresHistoryIntervalStopFoundEventsForLatestOnly()
     {
         SetupCachedAnalysis("https://lorem-ipsum.com", "main", "1m", CommitHistory.Full,
             RevisionHistoryMode.OnlyLatestRevision);
@@ -131,7 +131,7 @@ public class ComputeHistoryActivityTest
     }
 
     [Fact]
-    public async ValueTask FiresInvalidHistoryIntervalStopEvent()
+    public async Task FiresInvalidHistoryIntervalStopEvent()
     {
         // This could happen when we run the analysis on a codebase that barely has any commits.
         // If we want to analyse it, we have to be wary of the interval not being bigger than the age of the first commit.

--- a/Corgibytes.Freshli.Cli.Test/Functionality/History/HistoryIntervalStopFoundEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/History/HistoryIntervalStopFoundEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.History;
 public class HistoryIntervalStopFoundEventTest
 {
     [Fact]
-    public async ValueTask HandleFiresCreateApiHistoryIntervalStop()
+    public async Task HandleFiresCreateApiHistoryIntervalStop()
     {
         var cachedAnalysisId = Guid.NewGuid();
         const int historyStopPointId = 29;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/ComputeLibYearForPackageActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/ComputeLibYearForPackageActivityTest.cs
@@ -15,7 +15,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
 public class ComputeLibYearForPackageActivityTest
 {
     [Fact]
-    public async ValueTask HandleComputesLibYearAndFiresLibYearComputedForPackageEvent()
+    public async Task HandleComputesLibYearAndFiresLibYearComputedForPackageEvent()
     {
         var analysisId = Guid.NewGuid();
         var asOfDateTime = new DateTimeOffset(2021, 1, 29, 12, 30, 45, 0, TimeSpan.Zero);

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
@@ -14,7 +14,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
 public class DeterminePackagesFromBomActivityTest
 {
     [Fact]
-    public async ValueTask HandleCorrectlyFiresLibYearComputatitonForBomStartedEvent()
+    public async Task HandleCorrectlyFiresLibYearComputatitonForBomStartedEvent()
     {
         var analysisId = Guid.NewGuid();
         const string pathToBom = "/path/to/bom";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/LibYearComputedForPackageEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/LibYearComputedForPackageEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
 public class LibYearComputedForPackageEventTest
 {
     [Fact]
-    public async ValueTask HandleCorrectlyDispatchesCreateApiPackageLibYear()
+    public async Task HandleCorrectlyDispatchesCreateApiPackageLibYear()
     {
         var analysisId = Guid.NewGuid();
         const int historyStopPointId = 12;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/PackageFoundEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/PackageFoundEventTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
 public class PackageFoundEventTest
 {
     [Fact]
-    public async ValueTask HandleCorrectlyDispatchesComputeLibYearForPackageActivity()
+    public async Task HandleCorrectlyDispatchesComputeLibYearForPackageActivity()
     {
         var analysisId = Guid.NewGuid();
         const string agentExecutablePath = "/path/to/agent";

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/PackageLibYearCalculatorTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/PackageLibYearCalculatorTest.cs
@@ -14,7 +14,7 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
 public class PackageLibYearCalculatorTest
 {
     [Fact]
-    public async ValueTask VerifyItCanCalculateTheLibYear()
+    public async Task VerifyItCanCalculateTheLibYear()
     {
         const string packageName = "pkg:maven/org.apache.maven/apache-maven";
         var currentlyInstalledPackageUrl = new PackageURL(packageName + "@1.3.4");

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -53,7 +53,7 @@ public class AgentReaderTest
     }
 
     [Fact]
-    public async ValueTask RetrieveReleaseHistoryWritesToCache()
+    public async Task RetrieveReleaseHistoryWritesToCache()
     {
         const string agentExecutable = "/path/to/agent";
 
@@ -84,7 +84,7 @@ public class AgentReaderTest
     }
 
     [Fact]
-    public async ValueTask RetrieveReleaseHistoryReadsFromCache()
+    public async Task RetrieveReleaseHistoryReadsFromCache()
     {
         var initialCachedPackages = new List<CachedPackage>
         {

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
@@ -15,7 +15,7 @@ public class AgentReaderWithJavaAgentTest
 {
 
     [Fact]
-    public async ValueTask DetectManifestsUsingProtobuf()
+    public async Task DetectManifestsUsingProtobuf()
     {
         SetupDirectory(out var repositoryLocation, out var reader, out var checkoutDirectory);
 
@@ -34,7 +34,7 @@ public class AgentReaderWithJavaAgentTest
     }
 
     [Fact]
-    public async ValueTask GenerateBillOfMaterialsUsingProtobuf()
+    public async Task GenerateBillOfMaterialsUsingProtobuf()
     {
         SetupDirectory(out var repositoryLocation, out var reader, out var checkoutDirectory);
 
@@ -49,7 +49,7 @@ public class AgentReaderWithJavaAgentTest
     }
 
     [Fact]
-    public async ValueTask AgentReaderReturnsEmptyListWhenNoManifestsFound()
+    public async Task AgentReaderReturnsEmptyListWhenNoManifestsFound()
     {
         var checkoutLocation = CreateCheckoutLocation(out var checkoutDirectory);
         var reader = new AgentReader(new CacheManager(new Configuration(new Environment())), new CommandInvoker(),

--- a/Corgibytes.Freshli.Cli/Services/AgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentReader.cs
@@ -28,9 +28,16 @@ public class AgentReader : IAgentReader
     {
         var cachedPackages = _cacheDb.RetrieveCachedReleaseHistory(packageUrl);
 
+        var isUsingCache = false;
         await foreach (var cachedPackage in cachedPackages)
         {
+            isUsingCache = true;
             yield return cachedPackage.ToPackage();
+        }
+
+        if (isUsingCache)
+        {
+            yield break;
         }
 
         var packages = new List<Package>();


### PR DESCRIPTION
Works around a quirk with `xunit` that was causing any `async` tests to _always pass_.