### PR TITLE
Upgrade NLog.Extensions.* from 5.1.0 to 5.2.0

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NamedServices.Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="NLog" Version="5.1.0" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
-    <PackageReference Include="NLog.Extensions.Hosting" Version="5.1.0" />
+    <PackageReference Include="NLog.Extensions.Hosting" Version="5.2.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.1.0" />
     <PackageReference Include="packageurl-dotnet" Version="1.1.1" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="NLog" Version="5.1.0" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
     <PackageReference Include="NLog.Extensions.Hosting" Version="5.2.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.1.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.2.0" />
     <PackageReference Include="packageurl-dotnet" Version="1.1.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="ServiceStack.Text" Version="6.4.0" />


### PR DESCRIPTION
- Upgrade NLog.Extensions.Hosting from 5.1.0 to 5.2.0
- Upgrade NLog.Extensions.Logging from 5.1.0 to 5.2.0

Replaces:
- #429 
- #428 