### PR TITLE
Ensures that the aruba home directory is removed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-end_of_line = lf
 tab_width = 8
 
 [*.json]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Write-Output "HOME=$GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
+          Write-Output "HOME=$env:GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
 
       - name: "[Setup] - .NET Core"
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   ECLINT_VERSION: "0.3.3"
   _JAVA_OPTIONS: "-Xms10m -Xmx1024m"
+  HOME: ${{ env.GITHUB_WORKSPACE }}
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,22 +81,22 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: "[Build, Docker] - Set up QEMU"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/setup-qemu-action@v2
 
       - name: "[Build, Docker] - Set up Docker Buildx"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/setup-buildx-action@v2
 
       - name: "[Build, Docker] - Login to DockerHub"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "[Build, Docker] - Build and push"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
       BUILD_ARTIFACTS_FOLDER: build_artifacts
 
     steps:
-      - name: "[Setup] - Set HOME env variable (Windows)"
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: |
-          Write-Output "HOME=$GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
-
       - name: "[Setup] - Checkout code"
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Required for GitVersion
           submodules: 'recursive'
+
+      - name: "[Setup] - Set HOME env variable (Windows)"
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Write-Output "HOME=$GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
 
       - name: "[Setup] - .NET Core"
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 env:
   ECLINT_VERSION: "0.3.3"
   _JAVA_OPTIONS: "-Xms10m -Xmx1024m"
-  HOME: ${{ env.GITHUB_WORKSPACE }}
 
 jobs:
   build:
@@ -24,6 +23,12 @@ jobs:
       BUILD_ARTIFACTS_FOLDER: build_artifacts
 
     steps:
+      - name: "[Setup] - Set HOME env variable (Windows)"
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Write-Output "HOME=$GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
+
       - name: "[Setup] - Checkout code"
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
       BUILD_ARTIFACTS_FOLDER: build_artifacts
 
     steps:
+      - name: "[Setup] - Check null device status (Windows)"
+        if: runner.os != 'Windows'
+        shell: pwsh
+        run: |
+          sc query null
+
       - name: "[Setup] - Checkout code"
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,6 @@ jobs:
       BUILD_ARTIFACTS_FOLDER: build_artifacts
 
     steps:
-      - name: "[Setup] - Check null device status (Windows)"
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          sc query null
-
       - name: "[Setup] - Checkout code"
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Write-Output "HOME=$env:GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
+          "HOME=${env:GITHUB_WORKSPACE}" >> $env:GITHUB_ENV
 
       - name: "[Setup] - .NET Core"
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,15 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: "[Build, Docker] - Set up QEMU"
-        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/setup-qemu-action@v2
 
       - name: "[Build, Docker] - Set up Docker Buildx"
-        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/setup-buildx-action@v2
 
       - name: "[Build, Docker] - Login to DockerHub"
-        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: "[Lint] - Run all linters"
         run: |
-          bin/lint.rb
+          ruby bin/lint.rb
 
       - name: "[Test] - Install freshli-agent-java on Linux"
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: "[Setup] - Check null device status (Windows)"
-        if: runner.os != 'Windows'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           sc query null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
           fetch-depth: 0 # Required for GitVersion
           submodules: 'recursive'
 
-      - name: "[Setup] - Set HOME env variable (Windows)"
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: |
-          "HOME=${env:GITHUB_WORKSPACE}" >> $env:GITHUB_ENV
-
       - name: "[Setup] - .NET Core"
         uses: actions/setup-dotnet@v3
         with:
@@ -55,6 +49,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: "[Setup] - Set HOME env variable (Windows)"
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          "HOME=${env:GITHUB_WORKSPACE}" >> $env:GITHUB_ENV
 
       - name: "[Versioning] - GitVersion Config"
         uses: gittools/actions/gitversion/execute@v0.9.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "[Build, Docker] - Build and push"
-        if: {{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && runner.os != 'Windows' }}
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   CLAssistant:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/generate-diagram.yml
+++ b/.github/workflows/generate-diagram.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
       - name: "[Setup] - Checkout code"

--- a/bin/format.rb
+++ b/bin/format.rb
@@ -7,7 +7,7 @@ enable_dotnet_command_colors
 
 eclint_status = execute('eclint -fix')
 
-status = execute('bundle check > /dev/null')
+status = execute("bundle check > #{null_output_target}")
 status = execute('bundle install') unless status.success?
 
 resharper_status = execute('dotnet tool restore') if status.success?

--- a/bin/format.rb
+++ b/bin/format.rb
@@ -7,15 +7,13 @@ enable_dotnet_command_colors
 
 eclint_status = execute('eclint -fix')
 
-status = execute("bundle check > #{null_output_target}")
-status = execute('bundle install') unless status.success?
-
-resharper_status = execute('dotnet tool restore') if status.success?
+resharper_status = execute('dotnet tool restore')
 resharper_status = execute('dotnet jb cleanupcode freshli-cli.sln') if resharper_status.success?
 
-dotnet_format_status = execute('dotnet format --severity info') if status.success?
+dotnet_format_status = execute('dotnet format --severity info')
 
-rubocop_status = execute('bundle exec rubocop --autocorrect --color') if status.success?
+rubocop_status = execute('bundle install')
+rubocop_status = execute('bundle exec rubocop --autocorrect --color') if rubocop_status.success?
 
 composite_exitstatus =
   dotnet_format_status.exitstatus + rubocop_status.exitstatus + resharper_status.exitstatus + eclint_status.exitstatus

--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -63,7 +63,7 @@ if perform_eclint
 end
 
 if perform_rubocop
-  status = execute('bundle check > /dev/null')
+  status = execute("bundle check > #{null_output_target}")
   status = execute('bundle install') unless status.success?
 
   status = execute('bundle exec rubocop --color') if status.success?

--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -81,7 +81,10 @@ if perform_resharper
   status = execute('dotnet tool restore')
 
   if status.success?
-    execute('dotnet jb inspectcode freshli-cli.sln --build -o=resharper.temp -f=text')
+    execute(
+      'dotnet jb inspectcode --build --output=resharper.temp --format=text ' \
+      "--toolset-path=\"#{msbuild_dll_path}\" freshli-cli.sln"
+    )
     File.open('resharper.temp', 'r') do |f|
       result = f.readlines
       status = result.length == 1

--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -63,8 +63,7 @@ if perform_eclint
 end
 
 if perform_rubocop
-  status = execute("bundle check > #{null_output_target}")
-  status = execute('bundle install') unless status.success?
+  status = execute('bundle install')
 
   status = execute('bundle exec rubocop --color') if status.success?
 

--- a/bin/support/execute.rb
+++ b/bin/support/execute.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'mkmf'
+
+def msbuild_dll_path
+  dotnet_exe_path = find_executable('dotnet')
+  dotnet_dir = File.dirname(dotnet_exe_path)
+  sdk_dir = File.join(dotnet_dir, 'sdk', Dir.children(File.join(dotnet_dir, 'sdk')).max)
+  result = File.join(sdk_dir, 'MSBuild.dll')
+  result = result.gsub('/', '\\') if Gem.win_platform?
+  result
+end
+
+def null_output_target
+  Gem.win_platform? ? 'NUL:' : '/dev/null'
+end
 
 def enable_dotnet_command_colors
   ENV['DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION'] = 'true'

--- a/bin/support/execute.rb
+++ b/bin/support/execute.rb
@@ -13,7 +13,7 @@ def msbuild_dll_path
 end
 
 def null_output_target
-  Gem.win_platform? ? 'nul' : '/dev/null'
+  Gem.win_platform? ? '\\\\.\\nul' : '/dev/null'
 end
 
 def enable_dotnet_command_colors

--- a/bin/support/execute.rb
+++ b/bin/support/execute.rb
@@ -13,7 +13,7 @@ def msbuild_dll_path
 end
 
 def null_output_target
-  Gem.win_platform? ? 'NUL:' : '/dev/null'
+  Gem.win_platform? ? 'nul' : '/dev/null'
 end
 
 def enable_dotnet_command_colors

--- a/bin/test.rb
+++ b/bin/test.rb
@@ -46,8 +46,7 @@ ENV['_JAVA_OPTIONS'] = '-Xms10m -Xmx1024m' unless ENV['_JAVA_OPTIONS']
 status = execute("ruby #{File.dirname(__FILE__)}/build.rb") if perform_build
 
 if status.nil? || status.success?
-  status = execute("bundle check > #{null_output_target}")
-  status = execute('bundle install') unless status.success?
+  status = execute('bundle install')
 
   status = execute('dotnet test ./exe/Corgibytes.Freshli.Cli.Test.dll') if status.success?
   status = execute('bundle exec cucumber --color --backtrace') if status.success?

--- a/bin/test.rb
+++ b/bin/test.rb
@@ -46,7 +46,7 @@ ENV['_JAVA_OPTIONS'] = '-Xms10m -Xmx1024m' unless ENV['_JAVA_OPTIONS']
 status = execute("ruby #{File.dirname(__FILE__)}/build.rb") if perform_build
 
 if status.nil? || status.success?
-  status = execute('bundle check > /dev/null')
+  status = execute("bundle check > #{null_output_target}")
   status = execute('bundle install') unless status.success?
 
   status = execute('dotnet test ./exe/Corgibytes.Freshli.Cli.Test.dll') if status.success?

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -7,7 +7,7 @@ TWO_HOURS = 2 * 60 * 60
 # Contains helper methods for coping with platform specific differences
 module Platform
   def self.null_output_target
-    Gem.win_platform? ? 'NUL:' : '/dev/null'
+    Gem.win_platform? ? '\\\\.\\nul' : '/dev/null'
   end
 
   def self.normalize_file_separators(value)

--- a/features/support/filesystem.rb
+++ b/features/support/filesystem.rb
@@ -73,7 +73,7 @@ end
 
 def windows_safe_recursive_delete(path)
   path = normalize_and_expand_path(path)
-  raise "#{path} is not a directory" unless File.directory?(path)
+  return unless File.directory?(path)
 
   windows_safe_delete_directory_contents(path)
 

--- a/features/support/filesystem.rb
+++ b/features/support/filesystem.rb
@@ -26,14 +26,26 @@ def windows_safe_join(*paths)
   result
 end
 
+def expanded?(path)
+  path.start_with?('/') || path.start_with?('\\\\?')
+end
+
+def needs_unc_conversion?(path)
+  Gem.win_platform? && !path.start_with?('\\\\?')
+end
+
+def convert_to_unc(path)
+  windows_safe_join('\\\\?\\', path)
+end
+
 def normalize_and_expand_path(path)
-  unless path.start_with?('/') || path.start_with?('\\\\?')
+  unless expanded?(path)
     path = File.expand_path(path)
 
-    if Gem.win_platform? && !path.start_with?('\\\\?')
+    if needs_unc_conversion?(path)
       # Force path into UNC format. This works around issues with file names longer than the
       # default max on Windows, which is typically 260 characters
-      path = windows_safe_join('\\\\?\\', path)
+      path = convert_to_unc(path)
     end
   end
   path

--- a/features/support/filesystem.rb
+++ b/features/support/filesystem.rb
@@ -19,3 +19,48 @@ def resolve_path(path)
 
   path
 end
+
+def windows_safe_join(*paths)
+  result = File.join(paths)
+  if Gem.win_platform?
+    result = result.gsub('/', '\\')
+  end
+  result
+end
+
+def windows_safe_recursive_delete(path)
+  unless path.start_with?('/') || path.start_with?('\\\\?')
+    path = File.expand_path(path)
+
+    if Gem.win_platform? && !path.start_with?('\\\\?')
+      # Force path into UNC format. This works around issues with file names longer than the
+      # default max on Windows, which is typically 260 characters
+      path = windows_safe_join('\\\\?\\', path)
+    end
+  end
+
+  raise "#{path} is not a directory" unless File.directory?(path)
+
+  Dir.children(path).each do |entry|
+    entry_path = windows_safe_join(path, entry)
+    if File.directory?(entry_path)
+      windows_safe_recursive_delete(entry_path)
+    else
+      if Gem.win_platform?
+        # Remove read-only attribute from the file. This works around the removal of read-only
+        # directories being prohibited on Windows, even when `force: true` is specified.
+        FileUtils.chmod("a=rw", entry_path)
+      end
+
+      File.delete(entry_path)
+    end
+  end
+
+  if Gem.win_platform?
+    # Remove read-only attribute from the directory. This works around the removal of read-only
+    # directories being prohibited on Windows, even when `force: true` is specified.
+    FileUtils.chmod_R("a=rw", path)
+  end
+
+  Dir.rmdir(path)
+end

--- a/features/support/hooks/cleanup.rb
+++ b/features/support/hooks/cleanup.rb
@@ -2,6 +2,6 @@
 
 require 'fileutils'
 
-After do |scenario|
-  FileUtils.rm_rf(aruba.config.home_directory) if scenario.status == :passed
+Before do
+  windows_safe_recursive_delete(aruba.config.home_directory)
 end

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0",
+    "version": "7.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This includes a `windows_safe_recursive_delete` method that works around some quirks that crop up when deleting some of the git clones that can appear in the Aruba home directory.

The contents of the `.git` directory are marked as read-only, and that causes problems on Windows by default.

Also, on Windows, if the full path to a file becomes longer than around 260 characters, then `File.stat` will report that the file does not exist. This can be worked around, by prefixing the full path with `\\?\`, thus putting the path in UNC format. See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats for more information on the UNC path format.

While working on this I also discovered that linting wasn't running as part of the Windows builds. The `bin/lint.rb` file wasn't being run correctly. This discovery led to troubleshooting a lot of Windows specific problems when running that script on Windows in CI. These have been addressed.