### PR TITLE
Uses gRPC service for communicating with the Freshli agents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -245,3 +245,8 @@ max_line_length = unset
 [README.md]
 indent_size = unset
 max_line_length = unset
+
+[Corgibytes.Freshli.Cli/**/proto/*.cs]
+generated_code = true
+dotnet_analyzer_diagnostic.severity = none
+dotnet_diagnostic.CS8981.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ tab_width = 8
 indent_size = 2
 insert_final_newline = unset
 
+[*.proto]
+indent_size = 2
+
 # Generated code
 [*{_AssemblyInfo.cs,.notsupported.cs}]
 generated_code = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Write-Output "HOME=$env:GITHUB_WORKSPACE" | Out-File -Append $env:GITHUB_ENV
+          "HOME=${env:GITHUB_WORKSPACE}" >> $env:GITHUB_ENV
 
       - name: "[Setup] - .NET Core"
         uses: actions/setup-dotnet@v3

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Analysis/DetectManifestsUsingAgentActivityTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality;
@@ -29,7 +30,7 @@ public class DetectManifestsUsingAgentActivityTest
 
         const string agentExecutablePath = "/path/to/agent";
         var agentManager = new Mock<IAgentManager>();
-        agentManager.Setup(mock => mock.GetReader(agentExecutablePath)).Returns(agentReader.Object);
+        agentManager.Setup(mock => mock.GetReader(agentExecutablePath, CancellationToken.None)).Returns(agentReader.Object);
 
         var cacheManager = new Mock<ICacheManager>();
         var cacheDb = new Mock<ICacheDb>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality;
@@ -23,7 +24,7 @@ public class GenerateBillOfMaterialsActivityTest
 
         const string agentExecutablePath = "/path/to/agent";
         var agentManager = new Mock<IAgentManager>();
-        agentManager.Setup(mock => mock.GetReader(agentExecutablePath)).Returns(javaAgentReader.Object);
+        agentManager.Setup(mock => mock.GetReader(agentExecutablePath, CancellationToken.None)).Returns(javaAgentReader.Object);
 
         var cacheManager = new Mock<ICacheManager>();
         var cacheDb = new Mock<ICacheDb>();

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/ComputeLibYearForPackageActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/ComputeLibYearForPackageActivityTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality;
@@ -49,7 +50,7 @@ public class ComputeLibYearForPackageActivityTest
         var cacheDb = new Mock<ICacheDb>();
         var historyStopPoint = new CachedHistoryStopPoint { AsOfDateTime = asOfDateTime };
 
-        agentManager.Setup(mock => mock.GetReader(agentExecutablePath)).Returns(agentReader.Object);
+        agentManager.Setup(mock => mock.GetReader(agentExecutablePath, CancellationToken.None)).Returns(agentReader.Object);
         calculator.Setup(mock => mock.ComputeLibYear(agentReader.Object, package, asOfDateTime))
             .ReturnsAsync(packageLibYear);
         cacheManager.Setup(mock => mock.GetCacheDb()).Returns(cacheDb.Object);

--- a/Corgibytes.Freshli.Cli.Test/Helpers/CallHelpers.cs
+++ b/Corgibytes.Freshli.Cli.Test/Helpers/CallHelpers.cs
@@ -1,0 +1,65 @@
+﻿// This file was initially copied from https://github.com/grpc/grpc-dotnet/blob/948be08b088fbf449982b731c8e1a7cf8abb1965/examples/Tester/Tests/Client/Helpers/CallHelpers.cs
+// It is covered by the license below.
+
+// Some modifications have been added.
+
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Tests.Client.Helpers
+{
+    internal static class CallHelpers
+    {
+        public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(TResponse response)
+        {
+            return new AsyncUnaryCall<TResponse>(
+                Task.FromResult(response),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+
+        public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(StatusCode statusCode)
+        {
+            var status = new Status(statusCode, string.Empty);
+            return new AsyncUnaryCall<TResponse>(
+                Task.FromException<TResponse>(new RpcException(status)),
+                Task.FromResult(new Metadata()),
+                () => status,
+                () => new Metadata(),
+                () => { });
+        }
+
+        public static AsyncServerStreamingCall<TResponse> CreateAsyncServerStreamingCall<TResponse>(
+            IAsyncStreamReader<TResponse> responses)
+        {
+            return new AsyncServerStreamingCall<TResponse>(
+                responses,
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { }
+            );
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Helpers/CallHelpers.cs
+++ b/Corgibytes.Freshli.Cli.Test/Helpers/CallHelpers.cs
@@ -21,45 +21,45 @@
 
 #endregion
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 
-namespace Tests.Client.Helpers
+namespace Corgibytes.Freshli.Cli.Test.Helpers;
+
+internal static class CallHelpers
 {
-    internal static class CallHelpers
+    // ReSharper disable once UnusedMember.Global
+    public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(TResponse response)
     {
-        public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(TResponse response)
-        {
-            return new AsyncUnaryCall<TResponse>(
-                Task.FromResult(response),
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { });
-        }
+        return new AsyncUnaryCall<TResponse>(
+            Task.FromResult(response),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+    }
 
-        public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(StatusCode statusCode)
-        {
-            var status = new Status(statusCode, string.Empty);
-            return new AsyncUnaryCall<TResponse>(
-                Task.FromException<TResponse>(new RpcException(status)),
-                Task.FromResult(new Metadata()),
-                () => status,
-                () => new Metadata(),
-                () => { });
-        }
+    // ReSharper disable once UnusedMember.Global
+    public static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(StatusCode statusCode)
+    {
+        var status = new Status(statusCode, string.Empty);
+        return new AsyncUnaryCall<TResponse>(
+            Task.FromException<TResponse>(new RpcException(status)),
+            Task.FromResult(new Metadata()),
+            () => status,
+            () => new Metadata(),
+            () => { });
+    }
 
-        public static AsyncServerStreamingCall<TResponse> CreateAsyncServerStreamingCall<TResponse>(
-            IAsyncStreamReader<TResponse> responses)
-        {
-            return new AsyncServerStreamingCall<TResponse>(
-                responses,
-                Task.FromResult(new Metadata()),
-                () => Status.DefaultSuccess,
-                () => new Metadata(),
-                () => { }
-            );
-        }
+    public static AsyncServerStreamingCall<TResponse> CreateAsyncServerStreamingCall<TResponse>(
+        IAsyncStreamReader<TResponse> responses)
+    {
+        return new AsyncServerStreamingCall<TResponse>(
+            responses,
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { }
+        );
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentManagerTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentManagerTest.cs
@@ -13,7 +13,8 @@ public class AgentManagerTest
     {
         using var manager = new AgentManager(
             new CacheManager(new Configuration(new Environment())),
-            new NullLogger<AgentManager>()
+            new NullLogger<AgentManager>(),
+            new Configuration(new Environment())
         );
 
         var reader = manager.GetReader("freshli-agent-java");

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentManagerTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentManagerTest.cs
@@ -1,5 +1,6 @@
 using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Corgibytes.Freshli.Cli.Test.Services;
@@ -10,10 +11,13 @@ public class AgentManagerTest
     [Fact]
     public void GetReader()
     {
-        var manager = new AgentManager(new CacheManager(new Configuration(new Environment())), new CommandInvoker());
+        using var manager = new AgentManager(
+            new CacheManager(new Configuration(new Environment())),
+            new NullLogger<AgentManager>()
+        );
 
         var reader = manager.GetReader("freshli-agent-java");
 
-        Assert.Equal("freshli-agent-java", reader.AgentExecutablePath);
+        Assert.NotNull(reader);
     }
 }

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -1,14 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Corgibytes.Freshli.Agent;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Extensions;
 using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Services;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
 using Moq;
 using PackageUrl;
+using Tests.Client.Helpers;
 using Xunit;
+using Package = Corgibytes.Freshli.Cli.Functionality.Package;
 
 namespace Corgibytes.Freshli.Cli.Test.Services;
 
@@ -19,16 +25,14 @@ public class AgentReaderTest
     private readonly Package _betaPackage;
     private readonly Mock<ICacheDb> _cacheDb;
     private readonly Mock<ICacheManager> _cacheManager;
-    private readonly Mock<ICommandInvoker> _commandInvoker;
     private readonly List<Package> _expectedPackages;
     private readonly Package _gammaPackage;
     private readonly PackageURL _packageUrl;
     private readonly AgentReader _reader;
+    private readonly Mock<Agent.Agent.AgentClient> _agentClient;
 
     public AgentReaderTest()
     {
-        const string agentExecutable = "/path/to/agent";
-        _commandInvoker = new Mock<ICommandInvoker>();
         _cacheManager = new Mock<ICacheManager>();
         _cacheDb = new Mock<ICacheDb>();
         _packageUrl = new PackageURL("pkg:maven/org.example/package");
@@ -49,27 +53,46 @@ public class AgentReaderTest
         };
 
         _cacheManager.Setup(mock => mock.GetCacheDb()).Returns(_cacheDb.Object);
-        _reader = new AgentReader(_cacheManager.Object, _commandInvoker.Object, agentExecutable);
+        _agentClient = new Mock<Agent.Agent.AgentClient>();
+        _reader = new AgentReader(_cacheManager.Object, _agentClient.Object);
     }
 
     [Fact]
     public async Task RetrieveReleaseHistoryWritesToCache()
     {
-        const string agentExecutable = "/path/to/agent";
+        var serverResponse = new List<PackageRelease>()
+        {
+            new()
+            {
+                Version = _alphaPackage.PackageUrl.Version,
+                ReleasedAt = _alphaPackage.ReleasedAt.ToTimestamp()
+            },
+            new()
+            {
+                Version = _betaPackage.PackageUrl.Version,
+                ReleasedAt = _betaPackage.ReleasedAt.ToTimestamp()
+            },
+            new()
+            {
+                Version = _gammaPackage.PackageUrl.Version,
+                ReleasedAt = _gammaPackage.ReleasedAt.ToTimestamp()
+            }
+        };
 
-        var commandResponse =
-            $"{_alphaPackage.PackageUrl.Version}\t{_alphaPackage.ReleasedAt:yyyy'-'MM'-'dd'T'HH':'mm':'ssK}\n" +
-            $"{_betaPackage.PackageUrl.Version}\t{_betaPackage.ReleasedAt:yyyy'-'MM'-'dd'T'HH':'mm':'ssK}\n" +
-            $"{_gammaPackage.PackageUrl.Version}\t{_gammaPackage.ReleasedAt:yyyy'-'MM'-'dd'T'HH':'mm':'ssK}\n";
-
-        _commandInvoker.Setup(mock => mock.Run(agentExecutable,
-            $"retrieve-release-history {_packageUrl.FormatWithoutVersion()}", ".", 3)).ReturnsAsync(commandResponse);
+        _agentClient.Setup(
+            mock => mock.RetrieveReleaseHistory(
+                It.Is<Agent.Package>(value => value.Purl == _packageUrl.FormatWithoutVersion()),
+                null,
+                null,
+                It.IsAny<CancellationToken>()
+            )
+        ).Returns(CallHelpers.CreateAsyncServerStreamingCall(serverResponse.ToAsyncStreamReader()));
 
         _cacheManager.Setup(mock => mock.GetCacheDb()).Returns(_cacheDb.Object);
         _cacheDb.Setup(mock => mock.RetrieveCachedReleaseHistory(_packageUrl))
             .Returns(new List<CachedPackage>().ToAsyncEnumerable());
 
-        var reader = new AgentReader(_cacheManager.Object, _commandInvoker.Object, agentExecutable);
+        var reader = new AgentReader(_cacheManager.Object, _agentClient.Object);
 
         var retrievedPackages = reader.RetrieveReleaseHistory(_packageUrl);
 
@@ -101,3 +124,26 @@ public class AgentReaderTest
         Assert.Equal(_expectedPackages, await retrievedPackages.ToListAsync());
     }
 }
+
+class EnumerableStreamReader<T> : IAsyncStreamReader<T>
+{
+    private readonly IEnumerator<T> _enumerator;
+
+    public EnumerableStreamReader(IEnumerable<T> content)
+    {
+        _enumerator = content.GetEnumerator();
+    }
+
+    public Task<bool> MoveNext(CancellationToken cancellationToken) => Task.FromResult(_enumerator.MoveNext());
+
+    public T Current => _enumerator.Current;
+}
+
+static class ListExtensions
+{
+    public static IAsyncStreamReader<T> ToAsyncStreamReader<T>(this List<T> list)
+    {
+        return new EnumerableStreamReader<T>(list);
+    }
+}
+

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderTest.cs
@@ -8,11 +8,11 @@ using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Extensions;
 using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Services;
+using Corgibytes.Freshli.Cli.Test.Helpers;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Moq;
 using PackageUrl;
-using Tests.Client.Helpers;
 using Xunit;
 using Package = Corgibytes.Freshli.Cli.Functionality.Package;
 

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
@@ -19,7 +19,8 @@ public class AgentReaderWithJavaAgentTest : IDisposable
     {
         _agentManager = new AgentManager(
             new CacheManager(new Configuration(new Environment())),
-            new NullLogger<AgentManager>()
+            new NullLogger<AgentManager>(),
+            new Configuration(new Environment())
         );
     }
 

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
@@ -12,9 +12,9 @@ using Environment = Corgibytes.Freshli.Cli.Functionality.Environment;
 namespace Corgibytes.Freshli.Cli.Test.Services;
 
 [IntegrationTest]
-public class AgentReaderWithJavaAgentTest: IDisposable
+public class AgentReaderWithJavaAgentTest : IDisposable
 {
-    private AgentManager _agentManager;
+    private readonly AgentManager _agentManager;
     public AgentReaderWithJavaAgentTest()
     {
         _agentManager = new AgentManager(
@@ -113,5 +113,10 @@ public class AgentReaderWithJavaAgentTest: IDisposable
         checkoutDirectory.Delete(true);
     }
 
-    public void Dispose() => _agentManager.Dispose();
+    public void Dispose()
+    {
+        _agentManager.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
 }

--- a/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Services/AgentReaderWithJavaAgentTest.cs
@@ -5,14 +5,23 @@ using System.Linq;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Environment = Corgibytes.Freshli.Cli.Functionality.Environment;
 
 namespace Corgibytes.Freshli.Cli.Test.Services;
 
 [IntegrationTest]
-public class AgentReaderWithJavaAgentTest
+public class AgentReaderWithJavaAgentTest: IDisposable
 {
+    private AgentManager _agentManager;
+    public AgentReaderWithJavaAgentTest()
+    {
+        _agentManager = new AgentManager(
+            new CacheManager(new Configuration(new Environment())),
+            new NullLogger<AgentManager>()
+        );
+    }
 
     [Fact]
     public async Task DetectManifestsUsingProtobuf()
@@ -23,9 +32,9 @@ public class AgentReaderWithJavaAgentTest
 
         var expectedManifests = new List<string>
         {
-            Path.Combine("java","pom.xml"),
-            Path.Combine("java", "protoc", "pom.xml"),
-            Path.Combine("ruby", "pom.xml")
+            Path.GetFullPath(Path.Combine("java","pom.xml"), repositoryLocation),
+            Path.GetFullPath(Path.Combine("java", "protoc", "pom.xml"), repositoryLocation),
+            Path.GetFullPath(Path.Combine("ruby", "pom.xml"), repositoryLocation)
         };
         Assert.Equal(expectedManifests, actualManifests);
 
@@ -52,8 +61,8 @@ public class AgentReaderWithJavaAgentTest
     public async Task AgentReaderReturnsEmptyListWhenNoManifestsFound()
     {
         var checkoutLocation = CreateCheckoutLocation(out var checkoutDirectory);
-        var reader = new AgentReader(new CacheManager(new Configuration(new Environment())), new CommandInvoker(),
-            "freshli-agent-java");
+
+        var reader = _agentManager.GetReader("freshli-agent-java");
         var repositoryLocation = Path.Combine(checkoutLocation, "invalid_repository");
 
         var actualManifests = await reader.DetectManifests(repositoryLocation).ToListAsync();
@@ -61,7 +70,7 @@ public class AgentReaderWithJavaAgentTest
         RecursiveDelete(checkoutDirectory);
     }
 
-    private static void SetupDirectory(out string repositoryLocation, out AgentReader reader,
+    private void SetupDirectory(out string repositoryLocation, out IAgentReader reader,
         out DirectoryInfo checkoutDirectory)
     {
         var checkoutLocation = CreateCheckoutLocation(out checkoutDirectory);
@@ -72,8 +81,7 @@ public class AgentReaderWithJavaAgentTest
 
         repositoryLocation = Path.Combine(checkoutLocation, "protobuf");
 
-        reader = new AgentReader(new CacheManager(new Configuration(new Environment())), new CommandInvoker(),
-            "freshli-agent-java");
+        reader = _agentManager.GetReader("freshli-agent-java");
     }
 
     private static string CreateCheckoutLocation(out DirectoryInfo checkoutDirectory)
@@ -104,4 +112,6 @@ public class AgentReaderWithJavaAgentTest
 
         checkoutDirectory.Delete(true);
     }
+
+    public void Dispose() => _agentManager.Dispose();
 }

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -44,6 +44,14 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.39.0" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.39.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.40.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\CliOutput.resx">
@@ -57,5 +65,8 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>CliOutput.resx</DependentUpon>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="proto\freshli_agent.proto" GrpcServices="Client" />
   </ItemGroup>
 </Project>

--- a/Corgibytes.Freshli.Cli/Functionality/Configuration.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Configuration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace Corgibytes.Freshli.Cli.Functionality;
@@ -39,6 +40,9 @@ public class Configuration : IConfiguration
 
         set => _freshliWebApiBaseUrl = value != null! ? RemoveTrailingSlash(value) : value;
     }
+
+    public int WorkerCount { get; set; }
+    public int AgentServiceCount => Math.Max(WorkerCount / 4, 1);
 
     private static string RemoveTrailingSlash(string value) =>
         value.EndsWith("/") ? value.Remove(value.Length - 1, 1) : value;

--- a/Corgibytes.Freshli.Cli/Functionality/FreshliWeb/ResultsApi.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/FreshliWeb/ResultsApi.cs
@@ -5,60 +5,119 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Polly;
 
 namespace Corgibytes.Freshli.Cli.Functionality.FreshliWeb;
 
-public class ResultsApi : IResultsApi
+public class ResultsApi : IResultsApi, IDisposable
 {
     private readonly IConfiguration _configuration;
+    private readonly HttpClient _client;
 
-    public ResultsApi(IConfiguration configuration) => _configuration = configuration;
+    public ResultsApi(IConfiguration configuration, HttpClient client)
+    {
+        _configuration = configuration;
+        _client = client;
+    }
 
     // TODO: the results URL should use the base URL from the configuration
     public string GetResultsUrl(Guid analysisId) => "https://freshli.io/AnalysisRequests/" + analysisId;
 
-    public async ValueTask<Guid> CreateAnalysis(string url)
+    private class UnexpectedStatusCode : Exception
     {
-        var client = new HttpClient();
-
-        var response = await client.PostAsync(
-            _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request",
-            JsonContent.Create(
-                new
-                {
-                    name = "Freshli CLI User",
-                    email = "info@freshli.io",
-                    url
-                },
-                new MediaTypeHeaderValue("application/json")
-            )
-        );
-
-        if (response.StatusCode == HttpStatusCode.Created)
+        public UnexpectedStatusCode(HttpStatusCode expected, HttpStatusCode actual): base(BuildMessage(expected, actual))
         {
-            var document = await response.Content.ReadFromJsonAsync<JsonNode>();
-            return document!["id"]!.GetValue<Guid>();
         }
 
-        throw new InvalidOperationException($"Failed to create analysis with url: {url}.");
+        private static string BuildMessage(HttpStatusCode expected, HttpStatusCode actual)
+        {
+            return $"Expected status code {expected} but got {actual}";
+        }
+    }
+
+    private async ValueTask<T> ApiSendAsync<T>(HttpMethod method, string url, JsonContent? content,
+        HttpStatusCode expectedStatusCode, Func<HttpResponseMessage, Task<T>>? responseProcessor = null)
+    {
+        var uri = string.IsNullOrEmpty(url) ? null : new Uri(url, UriKind.RelativeOrAbsolute);
+        var request = new HttpRequestMessage(method, uri);
+        request.Content = content;
+
+        var response = await Policy
+            .Handle<HttpRequestException>()
+            .Or<TimeoutException>()
+            .WaitAndRetryAsync(6, retryAttempt =>
+                TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt / 2.0))
+            )
+            .ExecuteAsync(async () =>
+                // TODO: pass in a cancellation token
+                await _client.SendAsync(request));
+
+        if (response.StatusCode != expectedStatusCode)
+        {
+            throw new UnexpectedStatusCode(expectedStatusCode, response.StatusCode);
+        }
+
+        return responseProcessor != null ? await responseProcessor(response) : default!;
+    }
+
+    private async ValueTask<T> ApiSendAsync<T>(HttpMethod method, string url, JsonContent body,
+        HttpStatusCode expectedStatusCode,
+        Func<HttpResponseMessage, T>? responseProcessor = null)
+    {
+        return await ApiSendAsync(method, url, body, expectedStatusCode, (response) =>
+        {
+            var processorResult = responseProcessor != null ? responseProcessor(response) : default!;
+            return Task.FromResult(processorResult);
+        });
+    }
+
+    private async ValueTask ApiSendAsync(HttpMethod method, string url, JsonContent body, HttpStatusCode expectedStatusCode)
+    {
+        await ApiSendAsync(method, url, body, expectedStatusCode, _ => true);
+    }
+
+    public async ValueTask<Guid> CreateAnalysis(string url)
+    {
+        var apiUrl = _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request";
+        var requestBody = JsonContent.Create(new
+        {
+            name = "Freshli CLI User",
+            email = "info@freshli.io",
+            url
+        }, new MediaTypeHeaderValue("application/json"));
+
+        try
+        {
+            return await ApiSendAsync(HttpMethod.Post, apiUrl, requestBody, HttpStatusCode.Created, async (response) =>
+            {
+                var document = await response.Content.ReadFromJsonAsync<JsonNode>();
+                return document!["id"]!.GetValue<Guid>();
+            });
+        }
+        catch (Exception error)
+        {
+            throw new InvalidOperationException($"Failed to create analysis with url: {url}.", error);
+        }
     }
 
     public async ValueTask UpdateAnalysis(Guid apiAnalysisId, string status)
     {
-        var client = new HttpClient();
-
-        var response = await client.PutAsync(
-            _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request/" + apiAnalysisId,
-            JsonContent.Create(
-                new { state = status },
-                new MediaTypeHeaderValue("application/json")
-            )
+        var apiUrl = _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request/" + apiAnalysisId;
+        var requestBody = JsonContent.Create(
+            new { state = status },
+            new MediaTypeHeaderValue("application/json")
         );
 
-        if (response.StatusCode != HttpStatusCode.OK)
+        try
+        {
+            await ApiSendAsync(HttpMethod.Put, apiUrl, requestBody, HttpStatusCode.OK);
+        }
+        catch (Exception error)
         {
             throw new InvalidOperationException(
-                $"Failed to update analysis '{apiAnalysisId}' with state = '{status}'.");
+                $"Failed to update analysis '{apiAnalysisId}' with state = '{status}'.",
+                error
+            );
         }
     }
 
@@ -70,20 +129,22 @@ public class ResultsApi : IResultsApi
         var historyStopPoint = await cacheDb.RetrieveHistoryStopPoint(historyStopPointId);
         var asOfDateTime = historyStopPoint!.AsOfDateTime;
 
-        var client = new HttpClient();
-
-        var response = await client.PostAsync(
-            _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request/" + apiAnalysisId,
-            JsonContent.Create(
-                new { date = asOfDateTime.ToString("o") },
-                new MediaTypeHeaderValue("application/json")
-            )
+        var apiUrl = _configuration.FreshliWebApiBaseUrl + "/api/v0/analysis-request/" + apiAnalysisId;
+        var requestBody = JsonContent.Create(
+            new { date = asOfDateTime.ToString("o") },
+            new MediaTypeHeaderValue("application/json")
         );
 
-        if (response.StatusCode != HttpStatusCode.Created)
+        try
+        {
+            await ApiSendAsync(HttpMethod.Post, apiUrl, requestBody, HttpStatusCode.Created);
+        }
+        catch (Exception error)
         {
             throw new InvalidOperationException(
-                $"Failed to create history point for analysis '{apiAnalysisId}' with '{asOfDateTime}'.");
+                $"Failed to create history point for analysis '{apiAnalysisId}' with '{asOfDateTime}'.",
+                error
+            );
         }
     }
 
@@ -98,25 +159,29 @@ public class ResultsApi : IResultsApi
         var apiAnalysisId = cachedAnalysis!.ApiAnalysisId;
         var asOfDateTime = historyStopPoint!.AsOfDateTime;
 
-        var client = new HttpClient();
-
-        var response = await client.PostAsync(
-            $"{_configuration.FreshliWebApiBaseUrl}/api/v0/analysis-request/{apiAnalysisId}/{asOfDateTime:o}",
-            JsonContent.Create(
-                new
-                {
-                    packageUrl = packageLibYear.CurrentVersion!,
-                    publicationDate = packageLibYear.ReleaseDateCurrentVersion.ToString("o"),
-                    libYear = packageLibYear.LibYear
-                },
-                new MediaTypeHeaderValue("application/json")
-            )
+        var apiUrl = $"{_configuration.FreshliWebApiBaseUrl}/api/v0/analysis-request/{apiAnalysisId}/{asOfDateTime:o}";
+        var requestContent = JsonContent.Create(
+            new
+            {
+                packageUrl = packageLibYear.CurrentVersion!,
+                publicationDate = packageLibYear.ReleaseDateCurrentVersion.ToString("o"),
+                libYear = packageLibYear.LibYear
+            },
+            new MediaTypeHeaderValue("application/json")
         );
 
-        if (response.StatusCode != HttpStatusCode.Created)
+        try
+        {
+            await ApiSendAsync(HttpMethod.Post, apiUrl, requestContent, HttpStatusCode.Created);
+        }
+        catch (Exception error)
         {
             throw new InvalidOperationException(
-                $"Failed to create package lib year for analysis '{apiAnalysisId}' and '{asOfDateTime:o}' with package URL '{packageLibYear.CurrentVersion!}' publication date '{packageLibYear.ReleaseDateCurrentVersion:o}' and LibYear '{packageLibYear.LibYear}'.");
+                $"Failed to create package lib year for analysis '{apiAnalysisId}' and '{asOfDateTime:o}' with package URL '{packageLibYear.CurrentVersion!}' publication date '{packageLibYear.ReleaseDateCurrentVersion:o}' and LibYear '{packageLibYear.LibYear}'.",
+                error
+            );
         }
     }
+
+    public void Dispose() => _client.Dispose();
 }

--- a/Corgibytes.Freshli.Cli/Functionality/FreshliWeb/ResultsApi.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/FreshliWeb/ResultsApi.cs
@@ -25,7 +25,8 @@ public class ResultsApi : IResultsApi, IDisposable
 
     private class UnexpectedStatusCode : Exception
     {
-        public UnexpectedStatusCode(HttpStatusCode expected, HttpStatusCode actual): base(BuildMessage(expected, actual))
+        public UnexpectedStatusCode(HttpStatusCode expected, HttpStatusCode actual) :
+            base(BuildMessage(expected, actual))
         {
         }
 
@@ -39,8 +40,10 @@ public class ResultsApi : IResultsApi, IDisposable
         HttpStatusCode expectedStatusCode, Func<HttpResponseMessage, Task<T>>? responseProcessor = null)
     {
         var uri = string.IsNullOrEmpty(url) ? null : new Uri(url, UriKind.RelativeOrAbsolute);
-        var request = new HttpRequestMessage(method, uri);
-        request.Content = content;
+        var request = new HttpRequestMessage(method, uri)
+        {
+            Content = content
+        };
 
         var response = await Policy
             .Handle<HttpRequestException>()
@@ -71,7 +74,8 @@ public class ResultsApi : IResultsApi, IDisposable
         });
     }
 
-    private async ValueTask ApiSendAsync(HttpMethod method, string url, JsonContent body, HttpStatusCode expectedStatusCode)
+    private async ValueTask ApiSendAsync(HttpMethod method, string url, JsonContent body,
+        HttpStatusCode expectedStatusCode)
     {
         await ApiSendAsync(method, url, body, expectedStatusCode, _ => true);
     }
@@ -88,7 +92,8 @@ public class ResultsApi : IResultsApi, IDisposable
 
         try
         {
-            return await ApiSendAsync(HttpMethod.Post, apiUrl, requestBody, HttpStatusCode.Created, async (response) =>
+            return await ApiSendAsync(HttpMethod.Post, apiUrl, requestBody, HttpStatusCode.Created,
+                async (response) =>
             {
                 var document = await response.Content.ReadFromJsonAsync<JsonNode>();
                 return document!["id"]!.GetValue<Guid>();
@@ -183,5 +188,10 @@ public class ResultsApi : IResultsApi, IDisposable
         }
     }
 
-    public void Dispose() => _client.Dispose();
+    public void Dispose()
+    {
+        _client.Dispose();
+
+        GC.SuppressFinalize(this);
+    }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/IConfiguration.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/IConfiguration.cs
@@ -7,4 +7,8 @@ public interface IConfiguration
 
     // ReSharper disable once UnusedMemberInSuper.Global
     public string FreshliWebApiBaseUrl { get; set; }
+
+    public int WorkerCount { get; set; }
+
+    public int AgentServiceCount { get; }
 }

--- a/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
+++ b/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine.Hosting;
+using System.Net.Http;
 using Corgibytes.Freshli.Cli.CommandOptions;
 using Corgibytes.Freshli.Cli.CommandRunners;
 using Corgibytes.Freshli.Cli.CommandRunners.Cache;
@@ -33,10 +34,11 @@ public class FreshliServiceBuilder
         Services.AddSingleton(Configuration);
         Services.AddSingleton<IEnvironment, Environment>();
         Services.AddScoped<IExecutableFinder, ExecutableFinder>();
-        Services.AddScoped<ICacheManager, CacheManager>();
-        Services.AddScoped<IAgentManager, AgentManager>();
+        Services.AddSingleton<ICacheManager, CacheManager>();
+        Services.AddSingleton<IAgentManager, AgentManager>();
         Services.AddScoped<IHistoryIntervalParser, HistoryIntervalParser>();
         Services.AddScoped<IRunner, Runner>();
+        Services.AddSingleton<HttpClient>();
         RegisterBaseCommand();
         RegisterAnalyzeCommand();
         RegisterFailCommand();

--- a/Corgibytes.Freshli.Cli/Program.cs
+++ b/Corgibytes.Freshli.Cli/Program.cs
@@ -102,8 +102,10 @@ public class Program
 
                 if (workerCount == 0)
                 {
-                    workerCount = System.Environment.ProcessorCount * 2;
+                    workerCount = System.Environment.ProcessorCount;
                 }
+
+                Configuration.WorkerCount = workerCount;
 
                 Logger!.LogDebug("Starting workers. Worker count: {WorkerCount}", workerCount);
 

--- a/Corgibytes.Freshli.Cli/Program.cs
+++ b/Corgibytes.Freshli.Cli/Program.cs
@@ -98,21 +98,14 @@ public class Program
             .AddMiddleware(async (context, next) => { await LogExecution(context, next); })
             .AddMiddleware(async (context, next) =>
             {
-                var workerCount = context.ParseResult.GetOptionValueByName<int>("workers");
+                ParseWorkersOption(context);
 
-                if (workerCount == 0)
-                {
-                    workerCount = System.Environment.ProcessorCount;
-                }
-
-                Configuration.WorkerCount = workerCount;
-
-                Logger!.LogDebug("Starting workers. Worker count: {WorkerCount}", workerCount);
+                Logger!.LogDebug("Starting workers. Worker count: {WorkerCount}", Configuration.WorkerCount);
 
                 var host = context.BindingContext.GetRequiredService<IHost>();
 
                 var startTasks = new List<Task>();
-                while (Workers.Count < workerCount)
+                while (Workers.Count < Configuration.WorkerCount)
                 {
                     var worker = ActivatorUtilities.CreateInstance<QueuedHostedService>(host.Services);
                     Workers.Add(worker);
@@ -140,6 +133,18 @@ public class Program
             .UseHelp();
 
         return builder;
+    }
+
+    private static void ParseWorkersOption(InvocationContext context)
+    {
+        var workerCount = context.ParseResult.GetOptionValueByName<int>("workers");
+
+        if (workerCount == 0)
+        {
+            workerCount = System.Environment.ProcessorCount;
+        }
+
+        Configuration.WorkerCount = workerCount;
     }
 
     private static async Task LogExecution(InvocationContext context, Func<InvocationContext, Task> next)

--- a/Corgibytes.Freshli.Cli/Services/AgentManager.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentManager.cs
@@ -1,18 +1,294 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.EventStream;
+using CliWrap.Exceptions;
 using Corgibytes.Freshli.Cli.Functionality;
+using Grpc.Net.Client;
+using Microsoft.Extensions.Logging;
 
 namespace Corgibytes.Freshli.Cli.Services;
 
-public class AgentManager : IAgentManager
+public class AgentManager : IAgentManager, IDisposable
 {
-    private readonly ICacheManager _cacheManager;
-    private readonly ICommandInvoker _commandInvoker;
+    private const int MaxAgentReadersPerAgentExecutable = 5;
+    private const int ServiceStartTimeoutInSeconds = 2;
 
-    public AgentManager(ICacheManager cacheManager, ICommandInvoker commandInvoker)
+    private readonly ICacheManager _cacheManager;
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<AgentDescriptor>> _agentsByExecutable = new();
+
+    private readonly ILogger<AgentManager> _logger;
+    private readonly PortFinder _portFinder = new();
+
+    private static readonly List<Type> s_acceptableExceptions = new()
+    {
+        typeof(TaskCanceledException),
+        typeof(OperationCanceledException),
+        typeof(CommandExecutionException)
+    };
+
+    public AgentManager(ICacheManager cacheManager, ILogger<AgentManager> logger)
     {
         _cacheManager = cacheManager;
-        _commandInvoker = commandInvoker;
+        _logger = logger;
     }
 
-    public IAgentReader GetReader(string agentExecutablePath) =>
-        new AgentReader(_cacheManager, _commandInvoker, agentExecutablePath);
+    private ConcurrentQueue<AgentDescriptor> GetAgentsFor(string agentExecutablePath)
+    {
+        return _agentsByExecutable.GetOrAdd(agentExecutablePath, new ConcurrentQueue<AgentDescriptor>());
+    }
+
+    public IAgentReader GetReader(string agentExecutablePath, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Getting reader for {AgentExe}", agentExecutablePath);
+        var agents = GetAgentsFor(agentExecutablePath);
+
+        lock (agents)
+        {
+            AgentDescriptor agent;
+            if (agents.Count < MaxAgentReadersPerAgentExecutable)
+            {
+                _logger.LogDebug("Starting a new agent service");
+                var startAgentTask = StartAgentServiceOnAvailablePort(agentExecutablePath, cancellationToken);
+                WithAcceptableExceptions(() => startAgentTask.Wait(cancellationToken));
+
+                if (startAgentTask.Status != TaskStatus.RanToCompletion)
+                {
+                    _logger.LogDebug("Failed to start agent service");
+                    throw new AgentRetrievalFailure();
+                }
+
+                agent = startAgentTask.Result;
+                agents.Enqueue(agent);
+
+                _logger.LogDebug("Returning new agent reader {hash}", agent.AgentReader.GetHashCode());
+                return agent.AgentReader;
+            }
+
+            if (!agents.TryDequeue(out agent))
+            {
+                _logger.LogDebug("The agents queue is in an unexpected state");
+                throw new AgentRetrievalFailure();
+            }
+
+            _logger.LogDebug("Retrieving an existing agent reader {hash}", agent.AgentReader.GetHashCode());
+            agents.Enqueue(agent);
+            return agent.AgentReader;
+        }
+    }
+
+    private async Task<AgentDescriptor> StartAgentServiceOnAvailablePort(string agentExecutablePath, CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            _logger.LogDebug("Attempting to start an agent service");
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("Giving up because cancellation has been requested");
+                return default;
+            }
+
+            var port = _portFinder.FindNext();
+
+            var forcefulShutdown = new CancellationTokenSource();
+
+            var (agentRunnerTask, isServiceListening) = AttemptToStartAgentRunner(
+                agentExecutablePath, port, forcefulShutdown, cancellationToken);
+
+            if (isServiceListening)
+            {
+                var agentReader = CreateAgentReader(port);
+                return new AgentDescriptor(agentReader, agentRunnerTask, forcefulShutdown);
+            }
+
+            _logger.LogDebug(
+                "Failed to start agent {Agent} on port {Port}. Trying again.",
+                agentExecutablePath,
+                port
+            );
+
+            await ForcefullyShutdownAgentRunner(forcefulShutdown, agentRunnerTask);
+        }
+    }
+
+    private async Task ForcefullyShutdownAgentRunner(CancellationTokenSource forcefulShutdown, Task agentRunnerTask)
+    {
+        _logger.LogDebug("Stopping agent service runner (forcefully)");
+        forcefulShutdown.Cancel();
+        await WithAcceptableExceptionsAsync(async () => await agentRunnerTask);
+        forcefulShutdown.Dispose();
+    }
+
+    private AgentReader CreateAgentReader(int port)
+    {
+        _logger.LogDebug("Connecting to gRPC service on port {port}", port);
+        var channel = GrpcChannel.ForAddress($"http://localhost:{port}");
+        var grpcClient = new Agent.Agent.AgentClient(channel);
+        var agentReader = new AgentReader(_cacheManager, grpcClient);
+        return agentReader;
+    }
+
+    private (Task, bool) AttemptToStartAgentRunner(string agentExecutablePath, int port,
+        CancellationTokenSource forcefulShutdown, CancellationToken cancellationToken)
+    {
+        var isServiceListening = false;
+
+        var command = CliWrap.Cli.Wrap(agentExecutablePath).WithArguments(new List<string>
+        {
+            "start-server",
+            port.ToString()
+        });
+
+        _logger.LogDebug(
+            "Starting agent {Agent} service on port {Port}",
+            agentExecutablePath,
+            port
+        );
+        var agentRunnerTask = Task.Run(async () =>
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            var commandEvents = command.ListenAsync(
+                Encoding.UTF8,
+                Encoding.UTF8,
+                cancellationToken,
+                // ReSharper disable once AccessToDisposedClosure
+                forcefulShutdown.Token
+            );
+
+            // ReSharper disable once AccessToDisposedClosure
+            await foreach (var commandEvent in commandEvents.WithCancellation(forcefulShutdown.Token))
+            {
+                _logger.LogDebug("Received command event {event}", commandEvent);
+                switch (commandEvent)
+                {
+                    case StandardOutputCommandEvent output:
+                        isServiceListening = output.Text == $"Listening on {port}...";
+                        _logger.LogDebug(
+                            "Agent {Agent} is listening on port {Port}",
+                            agentExecutablePath,
+                            port
+                        );
+                        break;
+                }
+            }
+
+        }, cancellationToken);
+
+        _logger.LogDebug("Waiting for agent service to start listening");
+        var waitForStartTask = Task.Run(async () =>
+        {
+            while (true)
+            {
+                if (ShouldStopWaiting(isServiceListening, forcefulShutdown, cancellationToken))
+                {
+                    break;
+                }
+
+                await Task.Delay(10, cancellationToken);
+            }
+        }, cancellationToken);
+        waitForStartTask.Wait(TimeSpan.FromSeconds(ServiceStartTimeoutInSeconds), cancellationToken);
+        return (agentRunnerTask, isServiceListening);
+    }
+
+    private static bool ShouldStopWaiting(bool isServiceListening, CancellationTokenSource forcefulShutdown,
+        CancellationToken cancellationToken) =>
+        cancellationToken.IsCancellationRequested || forcefulShutdown.IsCancellationRequested || isServiceListening;
+
+    private static async ValueTask WithAcceptableExceptionsAsync(Func<ValueTask> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (AggregateException error)
+        {
+            if (!error.InnerExceptions.Any(exception => s_acceptableExceptions.Contains(exception.GetType())))
+            {
+                // Only rethrow if the exception is not one of the ones that are expected.
+                throw;
+            }
+        }
+        catch (Exception error)
+        {
+            if (!s_acceptableExceptions.Contains(error.GetType()))
+            {
+                // Only rethrow if the exception is not one of the ones that are expected.
+                throw;
+            }
+        }
+    }
+
+    private static void WithAcceptableExceptions(Action action)
+    {
+        WithAcceptableExceptionsAsync(() =>
+        {
+            action();
+            return ValueTask.CompletedTask;
+        }).AsTask().Wait();
+    }
+
+    private record struct AgentDescriptor(
+        IAgentReader AgentReader,
+        Task AgentServiceRunner,
+        CancellationTokenSource ForcefulShutdown
+    );
+
+    private List<AgentDescriptor> GetAllAgentDescriptors()
+    {
+        var result = new List<AgentDescriptor>();
+
+        foreach (var agents in _agentsByExecutable.Values)
+        {
+            result.AddRange(agents);
+        }
+
+        return result;
+    }
+
+    public void Dispose()
+    {
+        _logger.LogDebug("Dispose starting...");
+
+        _logger.LogDebug("Signaling service runner tasks to stop (forcefully)");
+        foreach (var agentDescriptor in GetAllAgentDescriptors())
+        {
+            agentDescriptor.ForcefulShutdown.Cancel();
+        }
+
+        _logger.LogDebug("Waiting for service runner tasks to stop");
+        try
+        {
+            Task.WaitAll(GetAllAgentDescriptors().Select(agent => agent.AgentServiceRunner).ToArray());
+        }
+        catch (TaskCanceledException)
+        {
+            // task cancellation is expected
+        }
+        catch (AggregateException error)
+        {
+            if (!error.InnerExceptions.All(value => value is TaskCanceledException))
+            {
+                // only rethrow if one of the exceptions is not the expected TaskCancellationException
+                throw;
+            }
+        }
+
+        _logger.LogDebug("Disposing service runner tasks");
+        foreach (var agent in GetAllAgentDescriptors())
+        {
+            agent.AgentServiceRunner.Dispose();
+            agent.ForcefulShutdown.Dispose();
+        }
+
+        _logger.LogDebug("Dispose complete");
+
+        GC.SuppressFinalize(this);
+    }
 }

--- a/Corgibytes.Freshli.Cli/Services/AgentManager.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentManager.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using CliWrap;
 using CliWrap.EventStream;
 using CliWrap.Exceptions;
 using Corgibytes.Freshli.Cli.Functionality;

--- a/Corgibytes.Freshli.Cli/Services/AgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Agent;
 using Corgibytes.Freshli.Cli.DataModel;
@@ -10,6 +11,7 @@ using Corgibytes.Freshli.Cli.Functionality;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using PackageUrl;
+using Polly;
 using Package = Corgibytes.Freshli.Cli.Functionality.Package;
 
 namespace Corgibytes.Freshli.Cli.Services;
@@ -44,8 +46,10 @@ public class AgentReader : IAgentReader
         var packages = new List<Package>();
 
         var request = new Agent.Package { Purl = packageUrl.FormatWithoutVersion() };
-        var response = _client.RetrieveReleaseHistory(request);
-        await foreach (var responseItem in response.ResponseStream.ReadAllAsync())
+
+        var results = RetryableRequestWithStreamResponse(
+            () => _client.RetrieveReleaseHistory(request));
+        await foreach (var responseItem in results)
         {
             var package = new Package(
                 new PackageURL(
@@ -65,10 +69,81 @@ public class AgentReader : IAgentReader
         await _cacheDb.StoreCachedReleaseHistory(packages.Select(package => new CachedPackage(package)).ToList());
     }
 
+    private static IAsyncEnumerable<T> RetryableRequestWithStreamResponse<T>(
+        Func<AsyncServerStreamingCall<T>> requester)
+    {
+        return new RetryableAsyncEnumerable<T>(requester);
+    }
+
+    class RetryableAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+        private readonly IAsyncEnumerable<T> _innerEnumerable;
+        private readonly Func<AsyncServerStreamingCall<T>> _requester;
+
+        public RetryableAsyncEnumerable(Func<AsyncServerStreamingCall<T>> requester)
+        {
+            _requester = requester;
+            _innerEnumerable = requester().ResponseStream.ReadAllAsync();
+        }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new RetryableAsyncEnumerator<T>(_innerEnumerable.GetAsyncEnumerator(cancellationToken), _requester);
+        }
+    }
+
+    class RetryableAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+        private IAsyncEnumerator<T> _innerEnumerator;
+        private int _index;
+        private readonly Func<AsyncServerStreamingCall<T>> _requester;
+
+        public RetryableAsyncEnumerator(IAsyncEnumerator<T> innerEnumerator, Func<AsyncServerStreamingCall<T>> requester)
+        {
+            _innerEnumerator = innerEnumerator;
+            _requester = requester;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _innerEnumerator.DisposeAsync();
+        }
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            bool result;
+            if (_index == 0)
+            {
+                result = await Policy
+                    .Handle<RpcException>()
+                    .WaitAndRetryAsync(6, retryAttempt =>
+                        TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt / 2.0)),
+                        onRetryAsync: async (_, _) =>
+                        {
+                            await _innerEnumerator.DisposeAsync();
+                            _innerEnumerator = _requester().ResponseStream.ReadAllAsync().GetAsyncEnumerator();
+                        }
+                    )
+                    .ExecuteAsync(async () => await _innerEnumerator.MoveNextAsync());
+            }
+            else
+            {
+                result = await _innerEnumerator.MoveNextAsync();
+            }
+            _index++;
+            return result;
+        }
+
+        public T Current => _innerEnumerator.Current;
+    }
+
     public async IAsyncEnumerable<string> DetectManifests(string projectPath)
     {
         var request = new ProjectLocation() { Path = Path.GetFullPath(projectPath) };
-        await foreach (var responseItem in _client.DetectManifests(request).ResponseStream.ReadAllAsync())
+        var results = RetryableRequestWithStreamResponse(
+            () => _client.DetectManifests(request));
+
+        await foreach (var responseItem in results)
         {
             yield return responseItem.Path;
         }
@@ -81,7 +156,12 @@ public class AgentReader : IAgentReader
             Manifest = new ManifestLocation() { Path = Path.GetFullPath(manifestPath) },
             Moment = asOfDateTime.ToTimestamp()
         };
-        var response = await _client.ProcessManifestAsync(request);
+        var response = await Policy
+            .Handle<RpcException>()
+            .WaitAndRetryAsync(6, retryAttempt =>
+                    TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt / 2.0))
+            )
+            .ExecuteAsync(async () => await _client.ProcessManifestAsync(request));
         return response.Path;
     }
 }

--- a/Corgibytes.Freshli.Cli/Services/AgentRetrievalFailure.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentRetrievalFailure.cs
@@ -2,4 +2,6 @@
 
 namespace Corgibytes.Freshli.Cli.Services;
 
-public class AgentRetrievalFailure: Exception {}
+public class AgentRetrievalFailure : Exception
+{
+}

--- a/Corgibytes.Freshli.Cli/Services/AgentRetrievalFailure.cs
+++ b/Corgibytes.Freshli.Cli/Services/AgentRetrievalFailure.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace Corgibytes.Freshli.Cli.Services;
+
+public class AgentRetrievalFailure: Exception {}

--- a/Corgibytes.Freshli.Cli/Services/IAgentManager.cs
+++ b/Corgibytes.Freshli.Cli/Services/IAgentManager.cs
@@ -1,6 +1,8 @@
+using System.Threading;
+
 namespace Corgibytes.Freshli.Cli.Services;
 
 public interface IAgentManager
 {
-    public IAgentReader GetReader(string agentExecutablePath);
+    public IAgentReader GetReader(string agentExecutablePath, CancellationToken cancellationToken = default);
 }

--- a/Corgibytes.Freshli.Cli/Services/IAgentReader.cs
+++ b/Corgibytes.Freshli.Cli/Services/IAgentReader.cs
@@ -8,7 +8,6 @@ namespace Corgibytes.Freshli.Cli.Services;
 
 public interface IAgentReader
 {
-    public string AgentExecutablePath { get; }
     public IAsyncEnumerable<Package> RetrieveReleaseHistory(PackageURL packageUrl);
     public IAsyncEnumerable<string> DetectManifests(string projectPath);
     public ValueTask<string> ProcessManifest(string manifestPath, DateTimeOffset asOfDateTime);

--- a/Corgibytes.Freshli.Cli/Services/PortFinder.cs
+++ b/Corgibytes.Freshli.Cli/Services/PortFinder.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Corgibytes.Freshli.Cli.Services;
@@ -8,19 +10,24 @@ public class PortFinder
     private const int MinPort = 1;
     private const int MaxPort = 65535;
 
-    private readonly ConcurrentBag<int> _possibleValues;
+    private readonly List<int> _possibleValues;
     private readonly ConcurrentBag<int> _attemptedValues = new();
+    private readonly Random _random = new();
 
     public PortFinder(int rangeStart = MinPort, int rangeStop = MaxPort)
     {
-        _possibleValues = new ConcurrentBag<int>(Enumerable.Range(rangeStart, rangeStop));
+        _possibleValues = new List<int>(Enumerable.Range(rangeStart, rangeStop));
     }
 
     public int FindNext()
     {
-        _possibleValues.TryTake(out var port);
-        _attemptedValues.Add(port);
-
-        return port;
+        lock (_possibleValues)
+        {
+            var index = _random.Next(_possibleValues.Count);
+            var value = _possibleValues[index];
+            _possibleValues.RemoveAt(index);
+            _attemptedValues.Add(value);
+            return value;
+        }
     }
 }

--- a/Corgibytes.Freshli.Cli/Services/PortFinder.cs
+++ b/Corgibytes.Freshli.Cli/Services/PortFinder.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Corgibytes.Freshli.Cli.Services;
+
+public class PortFinder
+{
+    private const int MinPort = 1;
+    private const int MaxPort = 65535;
+
+    private readonly ConcurrentBag<int> _possibleValues;
+    private readonly ConcurrentBag<int> _attemptedValues = new();
+
+    public PortFinder(int rangeStart = MinPort, int rangeStop = MaxPort)
+    {
+        _possibleValues = new ConcurrentBag<int>(Enumerable.Range(rangeStart, rangeStop));
+    }
+
+    public int FindNext()
+    {
+        _possibleValues.TryTake(out var port);
+        _attemptedValues.Add(port);
+
+        return port;
+    }
+}

--- a/Corgibytes.Freshli.Cli/proto/freshli_agent.proto
+++ b/Corgibytes.Freshli.Cli/proto/freshli_agent.proto
@@ -1,0 +1,47 @@
+﻿syntax = "proto3";
+
+package com.corgibytes.freshli.agent;
+
+option csharp_namespace = "Corgibytes.Freshli.Agent";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+service Agent {
+  rpc DetectManifests(ProjectLocation) returns (stream ManifestLocation);
+  rpc ProcessManifest(ProcessingRequest) returns (BomLocation);
+  rpc RetrieveReleaseHistory(Package) returns (stream PackageRelease);
+  rpc GetValidatingPackages(google.protobuf.Empty) returns (stream Package);
+  rpc GetValidatingRepositories(google.protobuf.Empty) returns (stream RepositoryLocation);
+  rpc Shutdown(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+message ProjectLocation {
+  string path = 1;
+}
+
+message ManifestLocation {
+  string path = 1;
+}
+
+message ProcessingRequest {
+  ManifestLocation manifest = 1;
+  google.protobuf.Timestamp moment = 2;
+}
+
+message BomLocation {
+  string path = 1;
+}
+
+message Package {
+  string purl = 1;
+}
+
+message PackageRelease {
+  string version = 1;
+  google.protobuf.Timestamp released_at = 2;
+}
+
+message RepositoryLocation {
+  string url = 1;
+}

--- a/features/step_definitions/api.rb
+++ b/features/step_definitions/api.rb
@@ -11,6 +11,8 @@ end
 
 # rubocop:disable Metrics/BlockLength
 Given('the Freshli Web API is available') do
+  raise 'API service does not have a valid port number' if api_service.port.nil?
+
   ENV['FRESHLI_WEB_API_BASE_URL'] = "http://localhost:#{api_service.port}"
 
   freshli_web_api

--- a/features/step_definitions/api.rb
+++ b/features/step_definitions/api.rb
@@ -5,7 +5,7 @@ require 'uri'
 api_service = nil
 Pact.service_consumer 'Freshli' do
   has_pact_with 'Web API' do
-    service = mock_service :freshli_web_api
+    api_service = mock_service :freshli_web_api
   end
 end
 

--- a/features/step_definitions/api.rb
+++ b/features/step_definitions/api.rb
@@ -2,17 +2,16 @@
 
 require 'uri'
 
+api_service = nil
 Pact.service_consumer 'Freshli' do
   has_pact_with 'Web API' do
-    mock_service :freshli_web_api do
-      port 52_077
-    end
+    service = mock_service :freshli_web_api
   end
 end
 
 # rubocop:disable Metrics/BlockLength
 Given('the Freshli Web API is available') do
-  ENV['FRESHLI_WEB_API_BASE_URL'] = 'http://localhost:52077'
+  ENV['FRESHLI_WEB_API_BASE_URL'] = "http://localhost:#{api_service.port}"
 
   freshli_web_api
     .upon_receiving('a request to create a new analysis')


### PR DESCRIPTION
This is an attempt to make performance improvements as part of #356.

* Starts up to 5 agent processes with the `start-service` command to run the gRPC service, and hands out `AgentReader` instances that communicate with those servers in a round-robin fashion.
* Adds retry logic to Freshli Web API calls, and also changes to a shared `HttpClient` instance. The retry logic should improve reliability, and the shared `HttpClient` instance should improve performance.
* Improves reliability of cache database reads by using retries when reading from the cache database.