### PR TITLE
Upgrades gRPC dependencies

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -46,7 +46,7 @@
     </None>
     <PackageReference Include="Google.Protobuf" Version="3.21.12" />
     <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.39.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.51.0" />
     <PackageReference Include="Grpc.Core.Api" Version="2.51.0" />
     <PackageReference Include="Grpc.Tools" Version="2.51.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -44,7 +44,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
     <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.39.0" />
     <PackageReference Include="Grpc.Core.Api" Version="2.51.0" />

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.39.0" />
     <PackageReference Include="Grpc.Core.Api" Version="2.39.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.40.0">
+    <PackageReference Include="Grpc.Tools" Version="2.51.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.18.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.39.0" />
-    <PackageReference Include="Grpc.Core.Api" Version="2.39.1" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.51.0" />
     <PackageReference Include="Grpc.Tools" Version="2.51.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -45,7 +45,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <PackageReference Include="Google.Protobuf" Version="3.21.12" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.51.0" />
     <PackageReference Include="Grpc.Core.Api" Version="2.51.0" />
     <PackageReference Include="Grpc.Tools" Version="2.51.0">


### PR DESCRIPTION
Upgrades all gRPC and Protobuf dependencies to their latest versions.

* Replaces #478 
* Replaces #477 
* Replaces #476 
* Replaces #475 
* Replaces #474