### PR TITLE
Bump Microsoft.CodeAnalysis.* from 4.6.0 to 4.7.0

### DIFF
--- a/tools/diagram-generator/diagram-generator.csproj
+++ b/tools/diagram-generator/diagram-generator.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.Metrics" Version="3.3.4" />
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
     </ItemGroup>


### PR DESCRIPTION
Bumps Microsoft CodeAnalysis dependencies from version 4.6.0 to 4.7.0.

These pull requests were opened by Dependabot, but they could not be merged, because the dependencies needed to be upgraded together.
- Closes #615 
- Closes #616 
- Closes #617