### PR TITLE
Persist analysis data in CycloneDX BOM

### DIFF
--- a/Corgibytes.Freshli.Cli.Test/Corgibytes.Freshli.Cli.Test.csproj
+++ b/Corgibytes.Freshli.Cli.Test/Corgibytes.Freshli.Cli.Test.csproj
@@ -34,4 +34,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Fixtures\Boms\" />
+  </ItemGroup>
+
 </Project>

--- a/Corgibytes.Freshli.Cli.Test/Fixtures.cs
+++ b/Corgibytes.Freshli.Cli.Test/Fixtures.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using IOPath = System.IO.Path;
+
+namespace Corgibytes.Freshli.Cli.Test;
+
+public static class Fixtures
+{
+    public static string Path(params string[] values)
+    {
+        var pristineFixturesPath = GetPristineFixturesPath();
+        var components = new List<string> { pristineFixturesPath };
+        components.AddRange(values);
+
+        var pristineResult = IOPath.Combine(components.ToArray());
+
+        if (!Directory.Exists(pristineResult) && !File.Exists(pristineResult))
+        {
+            throw new FixtureNotFoundException(pristineResult);
+        }
+
+        // create temp directory and then copy the fixture to it
+        var tempDir = IOPath.Combine(IOPath.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+
+        CopyFixturesToTemp(tempDir);
+
+        return pristineResult.Replace(pristineFixturesPath, tempDir);
+    }
+
+    private static string GetPristineFixturesPath()
+    {
+        var assemblyPath = Assembly.GetExecutingAssembly().Location;
+        var components = new List<string>()
+        {
+            Directory.GetParent(assemblyPath)!.ToString(),
+            "Fixtures"
+        };
+        return IOPath.Combine(components.ToArray());
+    }
+
+    private static void CopyFixturesToTemp(string tempLocation)
+    {
+        var pristineFixtures = GetPristineFixturesPath();
+
+        var directoriesToProcess = new HashSet<string> { pristineFixtures };
+
+        while (directoriesToProcess.Count > 0)
+        {
+            var currentDir = directoriesToProcess.First();
+            directoriesToProcess.Remove(currentDir);
+
+            foreach (var file in Directory.GetFiles(currentDir))
+            {
+                var tempFilePath = file.Replace(pristineFixtures, tempLocation);
+                File.Copy(file, tempFilePath);
+            }
+
+            foreach (var directory in Directory.GetDirectories(currentDir))
+            {
+                var targetDir = directory.Replace(pristineFixtures, tempLocation);
+                Directory.CreateDirectory(targetDir);
+                directoriesToProcess.Add(directory);
+            }
+        }
+    }
+
+    private class FixtureNotFoundException : FileNotFoundException
+    {
+        public FixtureNotFoundException(string value) : base($"File or directory not found within the `Fixtures` directory tree: {value}", value)
+        {
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Fixtures/Boms/sample-dotnet-bom.json
+++ b/Corgibytes.Freshli.Cli.Test/Fixtures/Boms/sample-dotnet-bom.json
@@ -1,0 +1,3362 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:da0d1ade-7b82-496b-94c4-9d98fa6c0a6a",
+  "version": 1,
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "CycloneDX module for .NET",
+        "version": "2.8.1.0"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "bom-ref": "TestProjectInDirectory@0.0.0",
+      "name": "TestProjectInDirectory",
+      "version": "0.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/DotNetEnv@1.4.0",
+      "author": "DotNetEnv",
+      "name": "DotNetEnv",
+      "version": "1.4.0",
+      "description": "A .NET library to load environment variables from .env files",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "4DE1F28398D71BA783376BAFD3989B986164ACA50566E2360E2B95FE835FBC720EB7FD932ED50395F298453A3249BBAF32D807143C3F38508496A14C068374BE"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://aka.ms/deprecateLicenseUrl",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "purl": "pkg:nuget/DotNetEnv@1.4.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/tonerdo/dotnet-env",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/tonerdo/dotnet-env",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Elasticsearch.Net@7.10.1",
+      "author": "Elastic and contributors",
+      "name": "Elasticsearch.Net",
+      "version": "7.10.1",
+      "description": "Exposes all the Elasticsearch API endpoints but leaves you in control of building the request and response bodies. \n      Comes with built in cluster failover/connection pooling support.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "9696296B45545865472EBB70131B81FB4E99AA830DD08A7CE613E37B591B8399018A7A9EB99CE6624B02D0C6EB466FE931D453166E3687E68E0BB873F2674310"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "copyright": "Elasticsearch BV",
+      "purl": "pkg:nuget/Elasticsearch.Net@7.10.1",
+      "externalReferences": [
+        {
+          "url": "https://github.com/elastic/elasticsearch-net",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/elastic/elasticsearch-net.git",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/HtmlAgilityPack@1.11.30",
+      "author": "ZZZ Projects,Simon Mourrier,Jeff Klawiter,Stephan Grell",
+      "name": "HtmlAgilityPack",
+      "version": "1.11.30",
+      "description": "This is an agile HTML parser that builds a read/write DOM and supports plain XPATH or XSLT (you actually don\u0027t HAVE to understand XPATH nor XSLT to use it, don\u0027t worry...). It is a .NET code library that allows you to parse \u0022out of the web\u0022 HTML files. The parser is very tolerant with \u0022real world\u0022 malformed HTML. The object model is very similar to what proposes System.Xml, but for HTML documents (or streams).",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "49F59D884C5FAA17D18DD1061909E4AA7AFB6D765F9F1CA36ED17B3C64C645C95095804B25B29F1A38B29A421350D4E4B4359AEBF49224BF920BA63C9741DD1C"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "Copyright \u00A9 ZZZ Projects Inc.",
+      "purl": "pkg:nuget/HtmlAgilityPack@1.11.30",
+      "externalReferences": [
+        {
+          "url": "http://html-agility-pack.net/",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/zzzprojects/html-agility-pack/",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/LibGit2Sharp@0.27.0-preview-0096",
+      "author": "LibGit2Sharp contributors",
+      "name": "LibGit2Sharp",
+      "version": "0.27.0-preview-0096",
+      "description": "LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .Net and Mono.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1DAD1556B2BDFA010F19E9DA5A077013CA6AF50F8B9B882FBBCF7405E0A563AA38D9C0619537678631187CDBECC7FD321923465064BFE4BF431EF27CD6CB8C3B"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://aka.ms/deprecateLicenseUrl",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "Copyright \u00A9 LibGit2Sharp contributors",
+      "purl": "pkg:nuget/LibGit2Sharp@0.27.0-preview-0096",
+      "externalReferences": [
+        {
+          "url": "https://github.com/libgit2/libgit2sharp/",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/libgit2/libgit2sharp",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/LibGit2Sharp.NativeBinaries@2.0.312",
+      "author": "LibGit2Sharp contributors",
+      "name": "LibGit2Sharp.NativeBinaries",
+      "version": "2.0.312",
+      "description": "Native binaries for LibGit2Sharp",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "25DC1167DD1CE75A7C5421241C9F5F89B47D810E83753EA431304D0FA429E0EFF9B913B03972BDC5F2FAEE822325FBAF61C54C2DA5715EBF279970D24671243E"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "purl": "pkg:nuget/LibGit2Sharp.NativeBinaries@2.0.312",
+      "externalReferences": [
+        {
+          "url": "https://github.com/libgit2/libgit2sharp.nativebinaries",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Microsoft.CSharp@4.6.0",
+      "author": "Microsoft",
+      "name": "Microsoft.CSharp",
+      "version": "4.6.0",
+      "description": "Provides support for compilation and code generation, including dynamic, using the C# language.\n\nCommonly Used Types:\nMicrosoft.CSharp.RuntimeBinder.Binder\nMicrosoft.CSharp.RuntimeBinder.RuntimeBinderException\nMicrosoft.CSharp.RuntimeBinder.CSharpArgumentInfo\nMicrosoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags\nMicrosoft.CSharp.RuntimeBinder.CSharpBinderFlags\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1190BC8E808E316CD31E670A57DDC6C04A2CA4489CCC792A8326944988D661ADED0EA4ABEE1EC1D4D677BFEFF32FD6B79F2AF018A9C68906ED4D6AA068DC3DDD"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation. All rights reserved.",
+      "purl": "pkg:nuget/Microsoft.CSharp@4.6.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dotnet/corefx",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+      "author": "Microsoft",
+      "name": "Microsoft.NETCore.Platforms",
+      "version": "1.1.0",
+      "description": "Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6BF892C274596FE2C7164E3D8503B24E187F64D0B7BEC6D9B05EB95F04086FCEB7A85EA6B2685D42DC465C52F6F0E6F636C0B3FDDAC48F6F0125DFD83E92D106"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+      "author": "Microsoft",
+      "name": "Microsoft.NETCore.Targets",
+      "version": "1.1.0",
+      "description": "Provides supporting infrastructure for portable projects: support identifiers that define framework and runtime for support targets and packages that reference the minimum supported package versions when targeting these. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1EF033A68688AAB9997EC1C0378ACB1638B4AFB618E533FCAF749D93389737BA94F4A0A94481BECDF701C7E988AE2FE390136A8EAE225887EE60DB45063490FE"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/Microsoft.Win32.Primitives@4.3.0",
+      "author": "Microsoft",
+      "name": "Microsoft.Win32.Primitives",
+      "version": "4.3.0",
+      "description": "Provides common types for Win32-based libraries.\n\nCommonly Used Types:\nSystem.ComponentModel.Win32Exception\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "366F07A79D72F6D61C2B7C43EAA938DD68DFB6B83599D1F6E02089B136FA82BEC74B6D54D6E03E08A3C612D51C5596E3535CBC2B29F39B97A827B3E7C79826F0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/Microsoft.Win32.Primitives@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/NETStandard.Library@1.6.1",
+      "author": "Microsoft",
+      "name": "NETStandard.Library",
+      "version": "1.6.1",
+      "description": "A set of standard .NET APIs that are prescribed to be used and supported together. This includes all of the APIs in the NETStandard.Platform package plus additional libraries that are core to .NET but built on top of NETStandard.Platform. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "0972DC2DBB4925E896F62BCE2E59D4E48639320EE38AD3016DCD485FBD6936A0ED08073AD5EEF2A612DFF05DFC390F3930FFF9E79D87A06070EEB8128277CBD0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/NETStandard.Library@1.6.1",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/NLog@4.7.7",
+      "author": "Jarek Kowalski,Kim Christensen,Julian Verdurmen",
+      "name": "NLog",
+      "version": "4.7.7",
+      "description": "NLog is a logging platform for .NET with rich log routing and management capabilities.\nNLog supports traditional logging, structured logging and the combination of both.\n\nSupported platforms:\n\n- .NET Framework 3.5, 4, 4.5, 4.6, 4.7 \u0026 4.8\n- .NET Core 1, 2 and 3\n- .NET Standard 1.3\u002B and 2.0\u002B;\n- .NET Framework 4 client profile\n- Xamarin Android, Xamarin iOs\n- UWP\n- Windows Phone 8\n- Silverlight 4 and 5\n- Mono 4\n\nFor ASP.NET Core, check: https://www.nuget.org/packages/NLog.Web.AspNetCore",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "45E890DE41C27DE1E7DFBB08D3A3A91B96ED6ABAB8AD3B36489134E47ABD53AD638719DABE82A74235934C578515DA8892C48DD0DF15079F0D882DCA33E033FC"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://github.com/NLog/NLog/blob/master/LICENSE.txt",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "Copyright (c) 2004-2021 NLog Project - https://nlog-project.org/",
+      "purl": "pkg:nuget/NLog@4.7.7",
+      "externalReferences": [
+        {
+          "url": "https://nlog-project.org/",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/NLog/NLog.git",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/RestSharp@106.11.7",
+      "author": "John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community",
+      "name": "RestSharp",
+      "version": "106.11.7",
+      "description": "Simple REST and HTTP API Client",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "C8163348E11A11AF78C15A21CBCE4015F26878796FDCE9BF54315C20F05588370203A1D5A2B113C95A68128996BBEDE9675200AE72F9CA71FA4F2D9F6B69B64B"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:nuget/RestSharp@106.11.7",
+      "externalReferences": [
+        {
+          "url": "http://restsharp.org/",
+          "type": "website"
+        },
+        {
+          "url": "https://github.com/restsharp/RestSharp.git",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "B2CF809FE50C4B46BD6F2372265CD3059622550123AFCEB5DBB2410906C07A7F47BAE4273584D29253D5E7A63A17C68C7BA0434608BBC8FD4D00E479B2F128FF"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "FD8E32D7D3E9A465202E391B0AB8B95E212900879BC4D8AC22954FD2D0F98FA579E9D25F88885AC2A4BF1EBA755DB940F8D131250A3FFEC34DBE77431A379CAB"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "4AFAC5CC1734330A6103880E790D639E825BFB1B34DBD42083762C47DB5E5DAB6C03EFD16049AC03861D7D87746CAED09C7534241D51B7341D47BA6AF7E8DD31"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.native.System@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.native.System",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "299C5A96FFFDCAF1972E3E3D1C727837D18AC9E88CB79C09914F12FF1DE7280DFF10C9232A49A1C1D3BA7785A5CF76F28C9DCE414F0A2A567688DE7FD5331DC8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.native.System@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.native.System.IO.Compression@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.native.System.IO.Compression",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "BFF1F0CAC94327014BB07C1EBEE06C216E6E4951B1DDAA0C8A753A4A0338BE621FD15EC621503490DBCA54A75809ABC4F420669B33052B28D24D726AC79C9891"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.native.System.IO.Compression@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.native.System.Net.Http@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.native.System.Net.Http",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "DDD1E5B67545477F7C72B5883666DE40E89EFB0836D91E7A349E2F3D4AC05CE1125E6ADD3CB09C39CBDFE7AB7C5DC8FDAEAF6AC25ACD92F6DE3D8CE2D6DB7918"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.native.System.Net.Http@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.native.System.Security.Cryptography.Apple",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "23C6A99B323CD71CDCB28C6FAA71F099F69FF0972D5125607AE8BBC99BA7C08513571D14526E8C2805AB3A8B70D3D3A6DD76DFA193320393ECB05906EE91F37D"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "EE5D047908B99B776FF9BB54856454B24B09A0F9271B127239543B1F5FAA3381A032D9EEB4D813D01B5A4B7D183B6A16250F159FDC450D5314A7EACE1550BEA3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "81BDB93C1C86C560343DF6CC367499FB2A01A9B3016617BE416874A23C4355A8D95C7BE34F175510F3FDEA4872302A87C8EFAB98A328DFA39422DB520C3F291C"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6DE9544B4DA49F127680CF5B3B4AFEA96BFCAC3293038A1B0A12EEA0AD60BE368AF31EE1DFD66D48D458B40200738C04AA0C71ADCC54AE2DDDBEA2CD50D6F28D"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "9929942914071E0EA0944A952FF9AD3C296BE39E719A2F4BB3EAC298D41829B4468B332FBA880EBE242871A02145E1C26DC7660021375D12C7EFCAE4D200278A"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "61DA1667A5DD1E53A5D19FBE90ABBFE332D84FE755FB811A080668A47D41A97DB44539E3174FD1D2A0770FF1BD83AFA68C82CE06DF5775DA65A6054CCC12C4BE"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E65A6A1F1928CFB760C395A399542DC7F9087399C53874376604504AE60ABD2DA24ED735EBD148D335000A5E35C8108EA55404685E902DF392EAC2E8D38FB665"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "C9F219515E268CF40E16B135BD64CBA95C35E866DD9BC34954159562314D01D2F9EA7EB8B0DB94ACF6BDAC83D651D90BAD7890CB657FFE40FA3440EC662C9944"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "4981B2D7A106703B185E176AD35BFDA149156F3B752778FA71C56B3686407765FD2B6625DE352BD563AAC1E1E8769D7886CC59A0D5D0BFB41ED60277360BEB81"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Internal implementation package not meant for direct consumption.  Please do not reference directly. \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "5DBE6BC007A9B46491E5299602291F5DBF8CC8D51E6C1B08DB2FA0EFD365990B41B6E181ED6BF82E873A659396427BC0E33E85B47D645D273FEF8BF8EC643631"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.AppContext@4.3.0",
+      "author": "Microsoft",
+      "name": "System.AppContext",
+      "version": "4.3.0",
+      "description": "Provides the System.AppContext class, which allows access to the BaseDirectory property and other application specific data.\n\nCommonly Used Types:\nSystem.AppContext\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "0D6EA63006304708FEAE2CC0590D2CDD99327B682210822BB2803AC842FDF4D8D57170D7947C006EEC4B5687C942768478A7EC109745472F3946D230732483E8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.AppContext@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Buffers@4.5.1",
+      "author": "Microsoft",
+      "name": "System.Buffers",
+      "version": "4.5.1",
+      "description": "Provides resource pooling of any type for performance-critical applications that allocate and deallocate objects frequently.\n\nCommonly Used Types:\nSystem.Buffers.ArrayPool\u003CT\u003E\n \n7601f4f6225089ffb291dc7d58293c7bbf5c5d4f \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "80DA6158E55B9BCF7E0B5E6379B9CF45A632914F037B53C5BF5609576E3CD7821F7861956B73D74470D2D0C2E56DD235A5EF4CA6FFE7E192B820DC2D023AAFF2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation. All rights reserved.",
+      "purl": "pkg:nuget/System.Buffers@4.5.1",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Collections@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Collections",
+      "version": "4.3.0",
+      "description": "Provides classes that define generic collections, which allow developers to create strongly typed collections that provide better type safety and performance than non-generic strongly typed collections.\n\nCommonly Used Types:\nSystem.Collections.Generic.List\u003CT\u003E\nSystem.Collections.Generic.Dictionary\u003CTKey, TValue\u003E\nSystem.Collections.Generic.Queue\u003CT\u003E\nSystem.Collections.Generic.Stack\u003CT\u003E\nSystem.Collections.Generic.HashSet\u003CT\u003E\nSystem.Collections.Generic.LinkedList\u003CT\u003E\nSystem.Collections.Generic.EqualityComparer\u003CT\u003E\nSystem.Collections.Generic.Comparer\u003CT\u003E\nSystem.Collections.Generic.SortedDictionary\u003CTKey, TValue\u003E\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "CA7B952D30DA1487CA4E43AA522817B5EE26E7E10537062810112FC67A7512766C39D402F394BB0426D1108BBCF9BBB64E9CE1F5AF736EF215A51A35E55F051B"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Collections@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Collections.Concurrent@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Collections.Concurrent",
+      "version": "4.3.0",
+      "description": "Provides several thread-safe collection classes that should be used in place of the corresponding types in the System.Collections.NonGeneric and System.Collections packages whenever multiple threads are accessing the collection concurrently.\n\nCommonly Used Types:\nSystem.Collections.Concurrent.ConcurrentDictionary\u003CTKey, TValue\u003E\nSystem.Collections.Concurrent.ConcurrentQueue\u003CT\u003E\nSystem.Collections.Concurrent.ConcurrentBag\u003CT\u003E\nSystem.Collections.Concurrent.BlockingCollection\u003CT\u003E\nSystem.Collections.Concurrent.ConcurrentStack\u003CT\u003E\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "35C1AA3E636216FE5DC2EBEB504293E69AD6355D26E22453AF060AF94D8279FAA93BDCFE127AECB0B316C7E7D9185BCAC72E994984EFDB7F2D8515F1F55CF682"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Collections.Concurrent@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Console@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Console",
+      "version": "4.3.0",
+      "description": "Provides the System.Console class, which represents the standard input, output and error streams for console applications.\n\nCommonly Used Types:\nSystem.Console\nSystem.ConsoleColor\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "A08A684A583C9B3278CE32BE1007DAE495F9D87254666392F794EF1203079F333CD7D388C28944FFA36FB49F0C8BB21F42C70F6E1D7C1C03920DF6D0D1130C82"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Console@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Diagnostics.Debug",
+      "version": "4.3.0",
+      "description": "Provides classes and attributes that allows basic interaction with a debugger.\n\nCommonly Used Types:\nSystem.Diagnostics.Debug\nSystem.Diagnostics.DebuggerStepThroughAttribute\nSystem.Diagnostics.Debugger\nSystem.Diagnostics.DebuggerDisplayAttribute\nSystem.Diagnostics.DebuggerBrowsableAttribute\nSystem.Diagnostics.DebuggerBrowsableState\nSystem.Diagnostics.DebuggerHiddenAttribute\nSystem.Diagnostics.DebuggerNonUserCodeAttribute\nSystem.Diagnostics.DebuggerTypeProxyAttribute\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6C58FE1E3618E7F87684C1CEA7EFC7D3B19BD7DF8D2535F9E27B62C52F441F11B67B21225D6BCD62F409E02C2A16231C4DB19BE33B8FAB5B9B0A5C8660DDAB24"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Diagnostics.DiagnosticSource@5.0.0",
+      "author": "Microsoft",
+      "name": "System.Diagnostics.DiagnosticSource",
+      "version": "5.0.0",
+      "description": "Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)\n\nCommonly Used Types:\nSystem.Diagnostics.DiagnosticListener\nSystem.Diagnostics.DiagnosticSource\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "BA21118BAD3B362FC480708C71E239368D4BCCBF2B2E0E5C83577D54205DB26B162F46E24B4FB846B641EBE80F4FA341790B0AEC8E725A0978F01B165E3BDDD7"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation. All rights reserved.",
+      "purl": "pkg:nuget/System.Diagnostics.DiagnosticSource@5.0.0",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dotnet/runtime",
+          "type": "website"
+        },
+        {
+          "url": "git://github.com/dotnet/runtime",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Diagnostics.Tools@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Diagnostics.Tools",
+      "version": "4.3.0",
+      "description": "Provides attributes, such as GeneratedCodeAttribute and SuppresMessageAttribute, that are emitted or consumed by analysis tools.\n\nCommonly Used Types:\nSystem.CodeDom.Compiler.GeneratedCodeAttribute\nSystem.Diagnostics.CodeAnalysis.SuppressMessageAttribute\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "164D6977E721CBCEB44EDE7BFD75B03B8D9771E0426AEFA5D40C71867E964092FDC6A6808BCBC5559ED73EC2C532CA657D6476AF79A49CA3AD879B8366F13D90"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Diagnostics.Tools@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Diagnostics.Tracing",
+      "version": "4.3.0",
+      "description": "Provides class that enable you to create high performance tracing events to be captured by event tracing for Windows (ETW).\n\nCommonly Used Types:\nSystem.Diagnostics.Tracing.EventSource\nSystem.Diagnostics.Tracing.EventListener\nSystem.Diagnostics.Tracing.EventLevel\nSystem.Diagnostics.Tracing.EventKeywords\nSystem.Diagnostics.Tracing.EventWrittenEventArgs\nSystem.Diagnostics.Tracing.EventAttribute\nSystem.Diagnostics.Tracing.EventSourceAttribute\nSystem.Diagnostics.Tracing.NonEventAttribute\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "D0A5D30E261CD45B7DFAB02B7FFBD76B64E0C9B892ED826EA61481C983C0208B05B69981CD79E91CD4E5811E1CD4C3CEA06A1AFCE05811ECE58BE5E4C20169EA"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Globalization@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Globalization",
+      "version": "4.3.0",
+      "description": "Provides classes that define culture-related information, including language, country/region, calendars in use, format patterns for dates, currency, and numbers, and sort order for strings.\n\nCommonly Used Types:\nSystem.Globalization.DateTimeFormatInfo\nSystem.Globalization.CultureInfo\nSystem.Globalization.NumberFormatInfo\nSystem.Globalization.CalendarWeekRule\nSystem.Globalization.TextInfo\nSystem.Globalization.Calendar\nSystem.Globalization.CompareInfo\nSystem.Globalization.CompareOptions\nSystem.Globalization.UnicodeCategory\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "823D2BA308CB073B40A3146ECCCD0D9FD7B1615AC3FBEFB16F73D873E411FD81C3BDC87DF206D3DC7E2F14C9CD53AAFCA684A3570C25471280AADA8DE805ECE2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Globalization@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Globalization.Calendars@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Globalization.Calendars",
+      "version": "4.3.0",
+      "description": "Provides classes for performing date calculations using specific calendars, including the Gregorian, Julian, Hijri and Korean calendars.\n\nCommonly Used Types:\nSystem.Globalization.HijriCalendar\nSystem.Globalization.GregorianCalendar\nSystem.Globalization.HebrewCalendar\nSystem.Globalization.KoreanCalendar\nSystem.Globalization.ThaiBuddhistCalendar\nSystem.Globalization.TaiwanCalendar\nSystem.Globalization.JapaneseCalendar\nSystem.Globalization.GregorianCalendarTypes\nSystem.Globalization.PersianCalendar\nSystem.Globalization.UmAlQuraCalendar\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E97190231402B393774B925EFC02A2BFA41D1D117A17FB87DA6E399F5234546962767E9CD8F39970EFA408E4F453CD1E6751A2A61E366BC97406E1B0B8A4BE86"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Globalization.Calendars@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Globalization.Extensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Globalization.Extensions",
+      "version": "4.3.0",
+      "description": "Provides classes for performing Unicode string normalization, culture-specific string comparisons and support the use of non-ASCII characters for Internet domain names.\n\nCommonly Used Types:\nSystem.StringNormalizationExtensions\nSystem.Text.NormalizationForm\nSystem.Globalization.IdnMapping\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "A4D360003F95E0C31EDF39C0B91E1C73850A60AC5D0032B17DB888A3C7D7134CEF9ACD97219D14174AD213B7C044F49B364CC5720073EBFCB6E1BF6E4EC24CE5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Globalization.Extensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.IO@4.3.0",
+      "author": "Microsoft",
+      "name": "System.IO",
+      "version": "4.3.0",
+      "description": "Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams\n\nCommonly Used Types:\nSystem.IO.Stream\nSystem.IO.EndOfStreamException\nSystem.IO.MemoryStream\nSystem.IO.StreamReader\nSystem.IO.StreamWriter\nSystem.IO.StringWriter\nSystem.IO.TextWriter\nSystem.IO.TextReader\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "BFCA5A21E3E1986B9765B13DC6FBCD6F8B89E4C1383855D1D7EF256BF1BF2F51889769DB5365859DD7606FBF6454ADD4DAEB3BAB56994FFB98FD1D03FE8BC1E6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.IO@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.IO.Compression@4.3.0",
+      "author": "Microsoft",
+      "name": "System.IO.Compression",
+      "version": "4.3.0",
+      "description": "Provides classes that support the compression and decompression of streams.\n\nCommonly Used Types:\nSystem.IO.Compression.DeflateStream\nSystem.IO.Compression.GZipStream\nSystem.IO.Compression.CompressionMode\nSystem.IO.Compression.CompressionLevel\nSystem.IO.Compression.ZipArchiveEntry\nSystem.IO.Compression.ZipArchive\nSystem.IO.Compression.ZipArchiveMode\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "F540EE51A3BB6941CDFBAACE9A9738D7F7986A2F94770DB61F45A88ECB7EF36B571D4C07417DC89CDBE9655A262B7CC599B0A4B78EFFEA91819E186121B44807"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.IO.Compression@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.IO.Compression.ZipFile@4.3.0",
+      "author": "Microsoft",
+      "name": "System.IO.Compression.ZipFile",
+      "version": "4.3.0",
+      "description": "Provides classes that support the compression and decompression of streams using file system paths.\n\nCommonly Used Types:\nSystem.IO.Compression.ZipFile\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1860634672767F818F0192EC2B2750693F0D39390F3B7D400CC6FD4F6E74A5CBED27BF49E5980EC85FF3E161C30F6190F700E339A1040C1699B87EB4AA7B6792"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.IO.Compression.ZipFile@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.IO.FileSystem@4.3.0",
+      "author": "Microsoft",
+      "name": "System.IO.FileSystem",
+      "version": "4.3.0",
+      "description": "Provides types that allow reading and writing to files and types that provide basic file and directory support.\n\nCommonly Used Types:\nSystem.IO.FileStream\nSystem.IO.FileInfo\nSystem.IO.DirectoryInfo\nSystem.IO.FileSystemInfo\nSystem.IO.File\nSystem.IO.Directory\nSystem.IO.SearchOption\nSystem.IO.FileOptions\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "4FB581D6F85B9529A091A0E974633752AA39E50B2BE6C8A9E5ECA8C2BC225CEA07064CCEC7778F77DF9987DEEBF4DCCEC050B1A97EDAC0EE9107142E6A8EE7EE"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.IO.FileSystem@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+      "author": "Microsoft",
+      "name": "System.IO.FileSystem.Primitives",
+      "version": "4.3.0",
+      "description": "Provides common enumerations and exceptions for path-based I/O libraries.\n\nCommonly Used Types:\nSystem.IO.DirectoryNotFoundException\nSystem.IO.FileAccess\nSystem.IO.FileLoadException\nSystem.IO.PathTooLongException\nSystem.IO.FileMode\nSystem.IO.FileShare\nSystem.IO.FileAttributes\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "5885953D09582CFFD973D23A21A929064D72F2BC9518AF3732D671FFFCC628A8B686F1D058A001EE6A114023B3E48B3FC0D0E4B22629A1C7F715E03795EE9EE5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Linq@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Linq",
+      "version": "4.3.0",
+      "description": "Provides classes and interfaces that supports queries that use Language-Integrated Query (LINQ).\n\nCommonly Used Types:\nSystem.Linq.Enumerable\nSystem.Linq.IGrouping\u003CTKey, TElement\u003E\nSystem.Linq.IOrderedEnumerable\u003CTElement\u003E\nSystem.Linq.ILookup\u003CTKey, TElement\u003E\nSystem.Linq.Lookup\u003CTKey, TElement\u003E\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "EACC7FE1EC526F405F5BA0E671F616D0E5BE9C1828D543A9E2F8C65DF4099D6B2EA4A9FA2CDAE4F34B170DC37142F60E267E137CA39F350281ED70D2DC620458"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Linq@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Linq.Expressions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Linq.Expressions",
+      "version": "4.3.0",
+      "description": "Provides classes, interfaces and enumerations that enable language-level code expressions to be represented as objects in the form of expression trees.\n\nCommonly Used Types:\nSystem.Linq.IQueryable\u003CT\u003E\nSystem.Linq.IQueryable\nSystem.Linq.Expressions.Expression\u003CTDelegate\u003E\nSystem.Linq.Expressions.Expression\nSystem.Linq.Expressions.ExpressionVisitor\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "61B90EF9AE6F779FBC8A7B6483EE8F5449CDD05C81B05235F70447E656A73B2AAB7C341784B999F7532374744A72E2C3A5CD13800EA23417FAC32CCFAE5CDE6D"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Linq.Expressions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Net.Http@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Net.Http",
+      "version": "4.3.0",
+      "description": "Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.\n\nCommonly Used Types:\nSystem.Net.Http.HttpResponseMessage\nSystem.Net.Http.DelegatingHandler\nSystem.Net.Http.HttpRequestException\nSystem.Net.Http.HttpClient\nSystem.Net.Http.MultipartContent\nSystem.Net.Http.Headers.HttpContentHeaders\nSystem.Net.Http.HttpClientHandler\nSystem.Net.Http.StreamContent\nSystem.Net.Http.FormUrlEncodedContent\nSystem.Net.Http.HttpMessageHandler\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E8105CE8151AEE95852FB29423F73CC1BD7C2286D36474ED7102A4B31248E45F434434A176D3AF0442738398C96C5753965EE0444FB9C97525ABBD9C88B13E41"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Net.Http@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Net.Primitives@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Net.Primitives",
+      "version": "4.3.0",
+      "description": "Provides common types for network-based libraries, including System.Net.IPAddress, System.Net.IPEndPoint, and System.Net.CookieContainer.\n\nCommonly Used Types:\nSystem.Net.HttpStatusCode\nSystem.Net.Sockets.SocketError\nSystem.Net.Cookie\nSystem.Net.Sockets.SocketException\nSystem.Net.IPEndPoint\nSystem.Net.ICredentials\nSystem.Net.NetworkCredential\nSystem.Net.IPAddress\nSystem.Net.CookieCollection\nSystem.Net.CookieContainer\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "9F7FDECE330A81F3312EA7C804927852413BEE2C929F3066B736993803DF47CC0692FBCA236C222BF19DC8F59B42F54F2A4C00DA9A4D624E458DA5874D127CE6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Net.Primitives@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Net.Sockets@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Net.Sockets",
+      "version": "4.3.0",
+      "description": "Provides classes such as Socket, TcpClient and UdpClient, which enable developers to send and receive data over the network.\n\nCommonly Used Types:\nSystem.Net.Sockets.Socket\nSystem.Net.Sockets.SocketAsyncEventArgs\nSystem.Net.Sockets.LingerOption\nSystem.Net.Sockets.SocketAsyncOperation\nSystem.Net.Sockets.ProtocolType\nSystem.Net.Sockets.NetworkStream\nSystem.Net.Sockets.TcpClient\nSystem.Net.Sockets.SocketType\nSystem.Net.Sockets.UdpClient\nSystem.Net.Sockets.SocketShutdown\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E32ED9518E9630E99EDCF1963C3D0E7047EA8252853C9260EB5403A4206170AE28FD27EB239F39DA4D2DB766F830B3EBDC9E4DA2E697BE20241D928082200955"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Net.Sockets@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.ObjectModel@4.3.0",
+      "author": "Microsoft",
+      "name": "System.ObjectModel",
+      "version": "4.3.0",
+      "description": "Provides types and interfaces that allow the creation of observable types that provide notifications to clients when changes are made to it.\n\nCommonly Used Types:\nSystem.ComponentModel.INotifyPropertyChanged\nSystem.Collections.ObjectModel.ObservableCollection\u003CT\u003E\nSystem.ComponentModel.PropertyChangedEventHandler\nSystem.Windows.Input.ICommand\nSystem.Collections.Specialized.INotifyCollectionChanged\nSystem.Collections.Specialized.NotifyCollectionChangedEventArgs\nSystem.Collections.Specialized.NotifyCollectionChangedEventHandler\nSystem.Collections.ObjectModel.KeyedCollection\u003CTKey, TItem\u003E\nSystem.ComponentModel.PropertyChangedEventArgs\nSystem.Collections.ObjectModel.ReadOnlyDictionary\u003CTKey, TValue\u003E\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "409BCA3D2139BD1D003C711400BA2DB5E576BB54D593AA541EC3576E7B2029B60159AB1C5B2C4E7389267B1B95EBCD8C2F064DC6E1F53E693AACB1737F066123"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.ObjectModel@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection",
+      "version": "4.3.0",
+      "description": "Provides types that retrieve information about assemblies, modules, members, parameters, and other entities in managed code by examining their metadata. These types also can be used to manipulate instances of loaded types, for example to hook up events or to invoke methods.\n\nCommonly Used Types:\nSystem.Reflection.MethodInfo\nSystem.Reflection.PropertyInfo\nSystem.Reflection.ParameterInfo\nSystem.Reflection.FieldInfo\nSystem.Reflection.ConstructorInfo\nSystem.Reflection.Assembly\nSystem.Reflection.MemberInfo\nSystem.Reflection.EventInfo\nSystem.Reflection.Module\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "2325B67ED60DCE0302807064F25422CBE1B7FB275B539B44FBA3C4A8CE4926F21D78529A5C34B31C03D80D110F7BACE9AF9589D457266BEAC014220057AF8333"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.Emit@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.Emit",
+      "version": "4.3.0",
+      "description": "Provides classes that allow a compiler or tool to emit metadata and optionally generate a PE file on disk. The primary clients of these classes are script engines and compilers.\n\nCommonly Used Types:\nSystem.Reflection.Emit.AssemblyBuilder\nSystem.Reflection.Emit.FieldBuilder\nSystem.Reflection.Emit.TypeBuilder\nSystem.Reflection.Emit.MethodBuilder\nSystem.Reflection.Emit.ConstructorBuilder\nSystem.Reflection.Emit.GenericTypeParameterBuilder\nSystem.Reflection.Emit.ModuleBuilder\nSystem.Reflection.Emit.PropertyBuilder\nSystem.Reflection.Emit.AssemblyBuilderAccess\nSystem.Reflection.Emit.EventBuilder\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "BE45051467A36AB965410F112A475FB81510A5595347D1CC0C46B028E0436A339218DD3C073F048C2D338B67DC13B45742290B6C46F55982503F74A8F2698818"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.Emit@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.Emit.ILGeneration",
+      "version": "4.3.0",
+      "description": "Provides classes that allow a compiler or tool to emit Microsoft intermediate language (MSIL). The primary clients of these classes are script engines and compilers.\n\nCommonly Used Types:\nSystem.Reflection.Emit.ILGenerator\nSystem.Reflection.Emit.Label\nSystem.Reflection.Emit.CustomAttributeBuilder\nSystem.Reflection.Emit.LocalBuilder\nSystem.Reflection.Emit.ParameterBuilder\nSystem.Reflection.Emit.SignatureHelper\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E9BE5F62BF64B1947A49857337306A5D0980686B58D665989E94006AB04AA7E0BBF4D8543D1B57D5BB38079052F275F339B73054A7357E4FA357208A0AC85D69"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.Emit.Lightweight",
+      "version": "4.3.0",
+      "description": "Provides the System.Reflection.Emit.DynamicMethod class, which represents a dynamic method that can be compiled, executed, and discarded. Discarded methods are available for garbage collection.\n\nCommonly Used Types:\nSystem.Reflection.Emit.DynamicMethod\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "AD58AF07296BD084907A089F92026FA3898B764EB9D6A07C9414B550A83AC60456F32A34127C29BB93A9633FB07BA9FD828F7B41A31DCE5FF019A7CF1AB29435"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.Extensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.Extensions",
+      "version": "4.3.0",
+      "description": "Provides custom attribute extension methods for System.Reflection types.\n\nCommonly Used Types:\nSystem.Reflection.InterfaceMapping\nSystem.Reflection.CustomAttributeExtensions\nSystem.Reflection.RuntimeReflectionExtensions\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "06CFD992C8D7FD9AB6432AB02BE981A01B6558285A6E26A7825A064D4EFCCE08D9E7344F03FA19B033A2459D42B0B80E8C1400CE39B47A1752869AB8825B0475"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.Extensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.Primitives@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.Primitives",
+      "version": "4.3.0",
+      "description": "Provides common enumerations for reflection-based libraries.\n\nCommonly Used Types:\nSystem.Reflection.FieldAttributes\nSystem.Reflection.Emit.OpCode\nSystem.Reflection.TypeAttributes\nSystem.Reflection.MethodAttributes\nSystem.Reflection.CallingConventions\nSystem.Reflection.PropertyAttributes\nSystem.Reflection.EventAttributes\nSystem.Reflection.ParameterAttributes\nSystem.Reflection.GenericParameterAttributes\nSystem.Reflection.MethodImplAttributes\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "D4B9CC905F5A5CAB900206338E889068BF66C18EE863A29D68EFF3CDE2CCCA734112A2A851F2E2E5388A21EC28005FA19317C64D9B23923B05D6344BE2E49EAA"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.Primitives@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Reflection.TypeExtensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Reflection.TypeExtensions",
+      "version": "4.3.0",
+      "description": "Provides extensions methods for System.Type that are designed to be source-compatible with older framework reflection-based APIs.\n\nCommonly Used Types:\nSystem.Reflection.TypeExtensions\nSystem.Reflection.BindingFlags\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "68AE81A635B9AF2AEE9FC8FC8FE7DA0356EF4DA4EB32F81A89FB75613B96714E8F1A1F4C12BD0D335EFBB03408CC7A744314837F13564D5FB262CA272055677F"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Reflection.TypeExtensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Resources.ResourceManager",
+      "version": "4.3.0",
+      "description": "Provides classes and attributes that allow developers to create, store, and manage various culture-specific resources used in an application.\n\nCommonly Used Types:\nSystem.Resources.ResourceManager\nSystem.Resources.NeutralResourcesLanguageAttribute\nSystem.Resources.SatelliteContractVersionAttribute\nSystem.Resources.MissingManifestResourceException\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "9067DB28F1C48D08FC52AD40A608F88C14AD9112646741DDAF426FDFE68BED61AB01954B179461E61D187371600C1E6E5C36C788993F5A105A64F5702A6B81D4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime",
+      "version": "4.3.0",
+      "description": "Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.\n\nCommonly Used Types:\nSystem.Object\nSystem.Exception\nSystem.Int16\nSystem.Int32\nSystem.Int64\nSystem.Enum\nSystem.String\nSystem.Char\nSystem.Boolean\nSystem.SByte\nSystem.Byte\nSystem.DateTime\nSystem.DateTimeOffset\nSystem.Single\nSystem.Double\nSystem.UInt16\nSystem.UInt32\nSystem.UInt64\nSystem.IDisposable\nSystem.Uri\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "92AB2249F08073CFAFDC4CFBD7DB36D651AD871B8D8BA961006982187DE374BF4A30AF93F15F73B05AF343F7A70CBD484B04D646570587636AE72171EB0714FB"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime.Extensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime.Extensions",
+      "version": "4.3.0",
+      "description": "Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.\n\nCommonly Used Types:\nSystem.Math\nSystem.Environment\nSystem.Random\nSystem.Progress\u003CT\u003E\nSystem.Convert\nSystem.Diagnostics.Stopwatch\nSystem.Runtime.Versioning.FrameworkName\nSystem.StringComparer\nSystem.IO.Path\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "680A32B19C2BD5026F8687AA5382AEA4F432B4F032F8BDE299FACB618C56D57369ADEF7F7CC8E60AD82AE3C12E5DD50772491363BF8044C778778628A6605BBC"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime.Extensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime.Handles@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime.Handles",
+      "version": "4.3.0",
+      "description": "Provides base classes, including System.Runtime.InteropServices.CriticalHandle and System.Runtime.InteropServices.SafeHandle, for types that represent operating system handles.\n\nCommonly Used Types:\nSystem.Runtime.InteropServices.SafeHandle\nMicrosoft.Win32.SafeHandles.SafeWaitHandle\nSystem.Runtime.InteropServices.CriticalHandle\nSystem.Threading.WaitHandleExtensions\nSystem.IO.HandleInheritability\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "0A5BAF1DD554BF9E01BCB4CE082CB26EE82B783364FEB47CBA730FAEECD70EDC528EFAD0394DCCE11F37D7F9507F8608F15629EBAF051906BFD3513E46AF0F11"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime.Handles@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime.InteropServices",
+      "version": "4.3.0",
+      "description": "Provides types that support COM interop and platform invoke services.\n\nCommonly Used Types:\nSystem.Runtime.InteropServices.GCHandle\nSystem.Runtime.InteropServices.GuidAttribute\nSystem.Runtime.InteropServices.COMException\nSystem.DllNotFoundException\nSystem.Runtime.InteropServices.DllImportAttribute\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "650799C3E654EFBB9AD67157C9C60CE46F288A81597BE37CE2A0BF5D4835044065EF3F65B997328CBBBBFB81F4C89B8D7E7D61380880019DEEE6EB3F963F70D9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime.InteropServices.RuntimeInformation",
+      "version": "4.3.0",
+      "description": "Provides APIs to query about runtime and OS information.\n\nCommonly Used Types:\nSystem.Runtime.InteropServices.RuntimeInformation\nSystem.Runtime.InteropServices.OSPlatform\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6F4905329A3CC9E62D274C885F275EE31C5AF57A6C9FD1A5080D039CB748E0277BEF3DC8CE42863CAC78365084E00A032279BF3D2B7254A49F3FB1566A29AD1B"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Runtime.Numerics@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Runtime.Numerics",
+      "version": "4.3.0",
+      "description": "Provides the numeric types System.Numerics.BigInteger and System.Numerics.Complex, which complement the numeric primitives, such as System.Byte, System.Double and System.Int32.\n\nCommonly Used Types:\nSystem.Numerics.BigInteger\nSystem.Numerics.Complex\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "3E347FAA8E7EC484D481E53B1C219FE1CE346AE8278A214B4508CF0E233C1627BD9C6C6C7C654E8C1F4143271838DDD9593F63A1043577AD87C40E392AF7FD34"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Runtime.Numerics@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.Algorithms",
+      "version": "4.3.0",
+      "description": "Provides base types for cryptographic algorithms, including hashing, encryption, and signing operations.\n\nCommonly Used Types:\nSystem.Security.Cryptography.Aes\nSystem.Security.Cryptography.RSA\nSystem.Security.Cryptography.RSAParameters\nSystem.Security.Cryptography.HMACSHA1\nSystem.Security.Cryptography.SHA256\nSystem.Security.Cryptography.SHA1\nSystem.Security.Cryptography.SHA512\nSystem.Security.Cryptography.SHA384\nSystem.Security.Cryptography.HMACSHA256\nSystem.Security.Cryptography.MD5\nSystem.Security.Cryptography.HMACSHA384\nSystem.Security.Cryptography.HMACSHA512\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "7641D70C2BA6F37BF429D5D949BDA427F078098C2DCB8924FD79B23BB22C4B956EF14235422D8B1CC5720CBBCC6CFEE8943D5FF87CE7ABF0D54C5E8BCE2AA5E2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.Cng@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.Cng",
+      "version": "4.3.0",
+      "description": "Provides cryptographic algorithm implementations and key management with Windows Cryptographic Next Generation API (CNG).\n\nCommonly Used Types:\nSystem.Security.Cryptography.RSACng\nSystem.Security.Cryptography.ECDsaCng\nSystem.Security.Cryptography.CngKey\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6272273414EAA777E78DCA1B5ECBBDF65E9659908082AEA924DF0975E71F4C1B47F85617EDF90EAD57078C29513A160CA62F123BE9F9F339DFB9C9386844F5EA"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.Cng@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.Csp@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.Csp",
+      "version": "4.3.0",
+      "description": "Provides cryptographic algorithm implementations and key management with Windows Cryptographic API (CryptoAPI).\n\nCommonly Used Types:\nSystem.Security.Cryptography.RSACryptoServiceProvider\nSystem.Security.Cryptography.CspParameters\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "43317591747A18F52F683187E09ADFE0E03573E6DAC430BF3BA13F440CDB1C7BB1F9205369D5F3B2A0F3FDF9604D5BA1E6D94A899A25D2C533E453338578F351"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.Csp@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.Encoding",
+      "version": "4.3.0",
+      "description": "Provides types for representing Abstract Syntax Notation One (ASN.1)-encoded data.\n\nCommonly Used Types:\nSystem.Security.Cryptography.AsnEncodedData\nSystem.Security.Cryptography.Oid\nSystem.Security.Cryptography.OidCollection\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "5C26ADD23E63542F37506F5FA1F72E8980F03743D529CD8E583D1054B8D8A579FB773FA035A00D9073DB84DB6BE4F47CAC340D1EBC6D23DD761DBDBD600075E0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.OpenSsl",
+      "version": "4.3.0",
+      "description": "Provides cryptographic algorithm implementations and key management for non-Windows systems with OpenSSL.\n\nCommonly Used Types:\nSystem.Security.Cryptography.RSAOpenSsl\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "64530A19489730F873F8C68E6B245135EA260C02D68591880261768358D0145795132BA5EE877741822FF05DCD0C61EDCA27696EF99E8F9302A21CADF3B1329F"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.Primitives",
+      "version": "4.3.0",
+      "description": "Provides common types for the cryptographic libraries.\n\nCommonly Used Types:\nSystem.Security.Cryptography.ICryptoTransform\nSystem.Security.Cryptography.AsymmetricAlgorithm\nSystem.Security.Cryptography.SymmetricAlgorithm\nSystem.Security.Cryptography.HashAlgorithm\nSystem.Security.Cryptography.KeyedHashAlgorithm\nSystem.Security.Cryptography.HMAC\nSystem.Security.Cryptography.KeySizes\nSystem.Security.Cryptography.CryptographicException\nSystem.Security.Cryptography.CipherMode\nSystem.Security.Cryptography.PaddingMode\nSystem.Security.Cryptography.CryptoStream\nSystem.Security.Cryptography.CryptoStreamMode\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "5AD8273F998EBB9CCA2F7BD03143D3F6D57B5D560657B26D6F4E78D038010FB30C379A23A27C08730F15C9B66F4BA565A06984EC246DFC79ACF1A741B0DD4347"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Security.Cryptography.X509Certificates",
+      "version": "4.3.0",
+      "description": "Provides types for reading, exporting and verifying Authenticode X.509 v3 certificates. These certificates are signed with a private key that uniquely and positively identifies the holder of the certificate.\n\nCommonly Used Types:\nSystem.Security.Cryptography.X509Certificates.X509Certificate2\nSystem.Security.Cryptography.X509Certificates.X509Certificate\nSystem.Security.Cryptography.X509Certificates.X509ContentType\nSystem.Security.Cryptography.X509Certificates.StoreLocation\nSystem.Security.Cryptography.X509Certificates.StoreName\nSystem.Security.Cryptography.X509Certificates.X509FindType\nSystem.Security.Cryptography.X509Certificates.X509ChainStatus\nSystem.Security.Cryptography.X509Certificates.X509Certificate2Collection\nSystem.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension\nSystem.Security.Cryptography.X509Certificates.X509Chain\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "318D86AB5528E2B444EC3E4B9824C1BE82BB93DB513EAB34B238E486F886C4D74310ED82C2110401FE5CD790E4D97F4A023A0B2D5C2E29952D3FD02E42734D00"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Text.Encoding@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Text.Encoding",
+      "version": "4.3.0",
+      "description": "Provides base abstract encoding classes for converting blocks of characters to and from blocks of bytes.\n\nCommonly Used Types:\nSystem.Text.Encoding\nSystem.Text.DecoderFallbackException\nSystem.Text.Decoder\nSystem.Text.EncoderFallbackException\nSystem.Text.Encoder\nSystem.Text.EncoderFallback\nSystem.Text.EncoderFallbackBuffer\nSystem.Text.DecoderFallback\nSystem.Text.DecoderFallbackBuffer\nSystem.Text.DecoderExceptionFallback\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6FF7FEEC7313A7121F795EC7D376E4B8728C17294219FAFDFD4EA078F9DF1455B4685F0B3962C3810098E95D68594A8392C0B799D36EC8284CD6FCBD4CFE2C67"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Text.Encoding@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Text.Encoding.Extensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Text.Encoding.Extensions",
+      "version": "4.3.0",
+      "description": "Provides support for specific encodings, including ASCII, UTF-7, UTF-8, UTF-16, and UTF-32.\n\nCommonly Used Types:\nSystem.Text.UTF8Encoding\nSystem.Text.UnicodeEncoding\nSystem.Text.ASCIIEncoding\nSystem.Text.UTF7Encoding\nSystem.Text.UTF32Encoding\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "E648C5DC781E35CF00C5CC8E7E42E815B963CF8FB788E8A817F9B53E318B2B42E2F7A556E9C3C64BF2F6A2FD4615F26AB4F0D4EB713A0151E71E0AF3FE9C3EED"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Text.Encoding.Extensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Text.RegularExpressions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Text.RegularExpressions",
+      "version": "4.3.0",
+      "description": "Provides the System.Text.RegularExpressions.Regex class, an implementation of a regular expression engine.\n\nCommonly Used Types:\nSystem.Text.RegularExpressions.Regex\nSystem.Text.RegularExpressions.RegexOptions\nSystem.Text.RegularExpressions.Match\nSystem.Text.RegularExpressions.Group\nSystem.Text.RegularExpressions.Capture\nSystem.Text.RegularExpressions.MatchEvaluator\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "80353C148DF30D9A2C03EE10A624D91B64D7CCC3218CB966344CFA70657F0B59C867FED2AB94057F64AB281AD9318353F25C23375C00E1376B6589AE0A70AAD3"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Text.RegularExpressions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Threading@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Threading",
+      "version": "4.3.0",
+      "description": "Provides the fundamental synchronization primitives, including System.Threading.Monitor and System.Threading.Mutex, that are required when writing asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Monitor\nSystem.Threading.SynchronizationContext\nSystem.Threading.ManualResetEvent\nSystem.Threading.AutoResetEvent\nSystem.Threading.ThreadLocal\u003CT\u003E\nSystem.Threading.EventWaitHandle\nSystem.Threading.SemaphoreSlim\nSystem.Threading.Mutex\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "97A2751BDCE69FAAF9C54F834A9FD5C60C7A786FAA52F420769828DBC9B5804C1F3721BA1EA945EA1D844835D909810F9E782C9A44D0FAAECCCB230C4CD95A88"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Threading@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Threading.Tasks@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Threading.Tasks",
+      "version": "4.3.0",
+      "description": "Provides types that simplify the work of writing concurrent and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.Task\u003CTResult\u003E\nSystem.Runtime.CompilerServices.TaskAwaiter\u003CTResult\u003E\nSystem.Threading.Tasks.TaskCompletionSource\u003CTResult\u003E\nSystem.Threading.Tasks.Task\nSystem.OperationCanceledException\nSystem.AggregateException\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "7D488FF82CB20A3B3CEF6380F2DAE5EA9F7BAA66BF75AD711AADE1E3301B25993CCF2694E33C847EA5B9BDB90FF34C46FCD8A6BA7D6F95605BA0C124ED7C5D13"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Threading.Tasks@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Threading.Tasks.Extensions@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Threading.Tasks.Extensions",
+      "version": "4.3.0",
+      "description": "Provides additional types that simplify the work of writing concurrent and asynchronous code.\n\nCommonly Used Types:\nSystem.Threading.Tasks.ValueTask\u003CTResult\u003E",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "2C33900FF7F544D6DB31AD11B6BAEE1C9ECB40D5A54F51E5DD5BBBB37F4C50EE35ED481615CBF7C1DA61A31AE3333C4454BFBEEE4AE32241789E72CE3F910DB6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Threading.Tasks.Extensions@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Threading.Timer@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Threading.Timer",
+      "version": "4.3.0",
+      "description": "Provides the System.Threading.Timer class, which is a mechanism for executing a method at specified intervals.\n\nCommonly Used Types:\nSystem.Threading.Timer\nSystem.Threading.TimerCallback\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "D5CE8E258B7BE7BE268F944E21621195948106F57E6C46E69B2887C46F567760368B14E84046B4BE4466ECD08ECD4CB04016A2FF7948CB4640960BEFC7AA1739"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Threading.Timer@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Xml.ReaderWriter@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Xml.ReaderWriter",
+      "version": "4.3.0",
+      "description": "Provides provides a fast, non-cached, forward-only way to read and write Extensible Markup Language (XML) data.\n\nCommonly Used Types:\nSystem.Xml.XmlNodeType\nSystem.Xml.XmlException\nSystem.Xml.XmlReader\nSystem.Xml.XmlWriter\nSystem.Xml.IXmlLineInfo\nSystem.Xml.XmlNameTable\nSystem.Xml.IXmlNamespaceResolver\nSystem.Xml.XmlNamespaceManager\nSystem.Xml.XmlQualifiedName\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "991101497FBD39E43FC306CA280A465318868AFA8DB1F34BB87C266FE61F0C81A0EC34A797B236EE823BD60D1149B7592DEF96FE044ABB511858EFFFE890C2E6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Xml.ReaderWriter@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:nuget/System.Xml.XDocument@4.3.0",
+      "author": "Microsoft",
+      "name": "System.Xml.XDocument",
+      "version": "4.3.0",
+      "description": "Provides the classes for Language-Integrated Query (LINQ) to Extensible Markup Language (XML). LINQ to XML is an in-memory XML programming interface that enables you to modify XML documents efficiently and easily.\n\nCommonly Used Types:\nSystem.Xml.Linq.XElement\nSystem.Xml.Linq.XAttribute\nSystem.Xml.Linq.XDocument\nSystem.Xml.Linq.XText\nSystem.Xml.Linq.XNode\nSystem.Xml.Linq.XContainer\nSystem.Xml.Linq.XComment\nSystem.Xml.Linq.XObject\nSystem.Xml.Linq.XProcessingInstruction\nSystem.Xml.Linq.XDocumentType\n \nWhen using NuGet 3.x this package requires at least version 3.4.",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "C2D9236A696DAF23A29B530B9AA510FB813041685A1BB9A95845A51E61D870A0615E988B150F5BE0D0896EF94B123E97F96C8A43EE815CF5B9897593986B1113"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "url": "http://go.microsoft.com/fwlink/?LinkId=329770",
+            "name": "Unknown - See URL"
+          }
+        }
+      ],
+      "copyright": "\u00A9 Microsoft Corporation.  All rights reserved.",
+      "purl": "pkg:nuget/System.Xml.XDocument@4.3.0",
+      "externalReferences": [
+        {
+          "url": "https://dot.net/",
+          "type": "website"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:nuget/DotNetEnv@1.4.0",
+      "dependsOn": [
+        "pkg:nuget/NETStandard.Library@1.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/Elasticsearch.Net@7.10.1",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.CSharp@4.6.0",
+        "pkg:nuget/System.Buffers@4.5.1",
+        "pkg:nuget/System.Diagnostics.DiagnosticSource@5.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/HtmlAgilityPack@1.11.30",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/LibGit2Sharp.NativeBinaries@2.0.312",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/LibGit2Sharp@0.27.0-preview-0096",
+      "dependsOn": [
+        "pkg:nuget/LibGit2Sharp.NativeBinaries@2.0.312"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/Microsoft.CSharp@4.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/Microsoft.Win32.Primitives@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/NETStandard.Library@1.6.1",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.Win32.Primitives@4.3.0",
+        "pkg:nuget/System.AppContext@4.3.0",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Collections.Concurrent@4.3.0",
+        "pkg:nuget/System.Console@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Diagnostics.Tools@4.3.0",
+        "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Globalization.Calendars@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.Compression@4.3.0",
+        "pkg:nuget/System.IO.Compression.ZipFile@4.3.0",
+        "pkg:nuget/System.IO.FileSystem@4.3.0",
+        "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+        "pkg:nuget/System.Linq@4.3.0",
+        "pkg:nuget/System.Linq.Expressions@4.3.0",
+        "pkg:nuget/System.Net.Http@4.3.0",
+        "pkg:nuget/System.Net.Primitives@4.3.0",
+        "pkg:nuget/System.Net.Sockets@4.3.0",
+        "pkg:nuget/System.ObjectModel@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Extensions@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+        "pkg:nuget/System.Runtime.Numerics@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Text.Encoding.Extensions@4.3.0",
+        "pkg:nuget/System.Text.RegularExpressions@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0",
+        "pkg:nuget/System.Threading.Timer@4.3.0",
+        "pkg:nuget/System.Xml.ReaderWriter@4.3.0",
+        "pkg:nuget/System.Xml.XDocument@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/NLog@4.7.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/RestSharp@106.11.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.native.System.IO.Compression@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/runtime.native.System.Net.Http@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/runtime.native.System@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/System.AppContext@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Buffers@4.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/System.Collections.Concurrent@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Collections@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Console@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Diagnostics.DiagnosticSource@5.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:nuget/System.Diagnostics.Tools@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Globalization.Calendars@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Globalization.Extensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Globalization@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.IO.Compression.ZipFile@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Buffers@4.5.1",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.Compression@4.3.0",
+        "pkg:nuget/System.IO.FileSystem@4.3.0",
+        "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.IO.Compression@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Buffers@4.5.1",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0",
+        "pkg:nuget/runtime.native.System@4.3.0",
+        "pkg:nuget/runtime.native.System.IO.Compression@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.IO.FileSystem@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.IO@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Linq.Expressions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Linq@4.3.0",
+        "pkg:nuget/System.ObjectModel@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Emit@4.3.0",
+        "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+        "pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0",
+        "pkg:nuget/System.Reflection.Extensions@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Reflection.TypeExtensions@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Linq@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Net.Http@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Diagnostics.DiagnosticSource@5.0.0",
+        "pkg:nuget/System.Diagnostics.Tracing@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Globalization.Extensions@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.FileSystem@4.3.0",
+        "pkg:nuget/System.Net.Primitives@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0",
+        "pkg:nuget/runtime.native.System@4.3.0",
+        "pkg:nuget/runtime.native.System.Net.Http@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Net.Primitives@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Net.Sockets@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Net.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.ObjectModel@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.Emit.Lightweight@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.Emit@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Emit.ILGeneration@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.Extensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.Primitives@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection.TypeExtensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Reflection@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime.Extensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime.Handles@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Extensions@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/runtime.native.System@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Reflection.Primitives@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime.Numerics@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Runtime@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Runtime.Numerics@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.Apple@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.Cng@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.Csp@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Collections.Concurrent@4.3.0",
+        "pkg:nuget/System.Linq@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Runtime.Numerics@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Security.Cryptography.X509Certificates@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.Globalization.Calendars@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.FileSystem@4.3.0",
+        "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.Handles@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Runtime.Numerics@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Algorithms@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Cng@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Csp@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Encoding@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.OpenSsl@4.3.0",
+        "pkg:nuget/System.Security.Cryptography.Primitives@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/runtime.native.System@4.3.0",
+        "pkg:nuget/runtime.native.System.Net.Http@4.3.0",
+        "pkg:nuget/runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Text.Encoding.Extensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Text.Encoding@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Text.RegularExpressions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Threading.Tasks.Extensions@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Threading.Tasks@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Threading.Timer@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/Microsoft.NETCore.Platforms@1.1.0",
+        "pkg:nuget/Microsoft.NETCore.Targets@1.1.0",
+        "pkg:nuget/System.Runtime@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Threading@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Xml.ReaderWriter@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.IO.FileSystem@4.3.0",
+        "pkg:nuget/System.IO.FileSystem.Primitives@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Runtime.InteropServices@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Text.Encoding.Extensions@4.3.0",
+        "pkg:nuget/System.Text.RegularExpressions@4.3.0",
+        "pkg:nuget/System.Threading.Tasks@4.3.0",
+        "pkg:nuget/System.Threading.Tasks.Extensions@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:nuget/System.Xml.XDocument@4.3.0",
+      "dependsOn": [
+        "pkg:nuget/System.Collections@4.3.0",
+        "pkg:nuget/System.Diagnostics.Debug@4.3.0",
+        "pkg:nuget/System.Diagnostics.Tools@4.3.0",
+        "pkg:nuget/System.Globalization@4.3.0",
+        "pkg:nuget/System.IO@4.3.0",
+        "pkg:nuget/System.Reflection@4.3.0",
+        "pkg:nuget/System.Resources.ResourceManager@4.3.0",
+        "pkg:nuget/System.Runtime@4.3.0",
+        "pkg:nuget/System.Runtime.Extensions@4.3.0",
+        "pkg:nuget/System.Text.Encoding@4.3.0",
+        "pkg:nuget/System.Threading@4.3.0",
+        "pkg:nuget/System.Xml.ReaderWriter@4.3.0"
+      ]
+    },
+    {
+      "ref": "TestProjectInDirectory@0.0.0",
+      "dependsOn": [
+        "pkg:nuget/DotNetEnv@1.4.0",
+        "pkg:nuget/Elasticsearch.Net@7.10.1",
+        "pkg:nuget/HtmlAgilityPack@1.11.30",
+        "pkg:nuget/LibGit2Sharp@0.27.0-preview-0096",
+        "pkg:nuget/NLog@4.7.7",
+        "pkg:nuget/RestSharp@106.11.7"
+      ]
+    }
+  ]
+}

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivityTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.History;
+using Moq;
+using Xunit;
+
+namespace Corgibytes.Freshli.Cli.Test.Functionality.BillOfMaterials;
+
+public class AddLibYearMetadataDataToBomActivityTest
+{
+    private const string PathToBom = "/path/to/bom";
+    private const string AgentExecutablePath = "/path/to/agent";
+
+    private readonly Mock<IApplicationEventEngine> _engine = new();
+    private readonly CancellationToken _cancellationToken = new();
+    private readonly AddLibYearMetadataDataToBomActivity _activity;
+
+    public AddLibYearMetadataDataToBomActivityTest()
+    {
+        _activity = new AddLibYearMetadataDataToBomActivity
+        {
+            Parent = _activity,
+            PathToBom = PathToBom,
+            AgentExecutablePath = AgentExecutablePath
+        };
+    }
+
+    [Fact(Timeout = Constants.DefaultTestTimeout)]
+    public async Task Handle()
+    {
+        var billOfMaterialsProcessor = new Mock<IBillOfMaterialsProcessor>();
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(mock => mock.GetService(typeof(IBillOfMaterialsProcessor)))
+            .Returns(billOfMaterialsProcessor.Object);
+        _engine.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
+
+        await _activity.Handle(_engine.Object, _cancellationToken);
+
+        billOfMaterialsProcessor.Verify(mock =>
+            mock.AddLibYearMetadataDataToBom(AgentExecutablePath, PathToBom, _cancellationToken)
+        );
+
+        _engine.Verify(mock => mock.Fire(
+            It.Is<LibYearMetadataAddedToBomEvent>(value =>
+                value.Parent == _activity &&
+                value.PathToBom == PathToBom &&
+                value.AgentExecutablePath == AgentExecutablePath
+            ),
+            _cancellationToken,
+            ApplicationTaskMode.Tracked
+        ));
+    }
+
+    [Fact(Timeout = Constants.DefaultTestTimeout)]
+    public async Task HandleFiresHistoryStopPointProcessingFailedOnException()
+    {
+        var exception = new Exception("Sample exception");
+        _engine.Setup(mock => mock.ServiceProvider).Throws(exception);
+
+        await _activity.Handle(_engine.Object, _cancellationToken);
+
+        _engine.Verify(mock =>
+            mock.Fire(
+                It.Is<HistoryStopPointProcessingFailedEvent>(value =>
+                    value.Parent == _activity &&
+                    value.Exception == exception
+                ),
+                _cancellationToken,
+                ApplicationTaskMode.Tracked
+            )
+        );
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/BillOfMaterialsProcessorTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/BillOfMaterialsProcessorTest.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.DataModel;
+using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+using CycloneDX.Models;
+using Xunit;
+
+namespace Corgibytes.Freshli.Cli.Test.Functionality.BillOfMaterials;
+
+[IntegrationTest]
+public static class BillOfMaterialsProcessorTest
+{
+    public class AnalysisMetadata : IAsyncLifetime
+    {
+        private const string AgentExecutablePath = "/path/to/agent";
+        private static string SourceBomFile { get; } = Fixtures.Path("Boms", "sample-dotnet-bom.json");
+        private static Guid AnalysisId { get; } = Guid.NewGuid();
+        private static DateTimeOffset CreatedAt { get; } = DateTimeOffset.Now;
+        private static DateTimeOffset AsOfDate { get; } = DateTimeOffset.Parse("2021-01-01T00:00:00Z");
+
+        private static CachedAnalysis? s_analysis;
+
+        private static CachedAnalysis Analysis
+        {
+            get
+            {
+                s_analysis ??= new CachedAnalysis()
+                {
+                    Id = AnalysisId,
+                    CreatedAt = CreatedAt
+                };
+                return s_analysis;
+            }
+        }
+
+        private static CachedGitSource? s_gitSource;
+
+        private static CachedGitSource GitSource
+        {
+            get
+            {
+                s_gitSource ??= new CachedGitSource
+                {
+                    Id = "source-id",
+                    Url = "/path/to/repo.git",
+                    Branch = "main",
+                };
+                return s_gitSource;
+            }
+        }
+
+        private static CachedHistoryStopPoint? s_historyStopPoint;
+
+        private static CachedHistoryStopPoint HistoryStopPoint
+        {
+            get
+            {
+                s_historyStopPoint ??= new CachedHistoryStopPoint
+                {
+                    Id = 29,
+                    CachedAnalysis = Analysis,
+                    AsOfDateTime = AsOfDate,
+                    Repository = GitSource
+                };
+                return s_historyStopPoint;
+            }
+        }
+
+        private static CachedManifest? s_manifest;
+
+        private static CachedManifest Manifest
+        {
+            get
+            {
+                s_manifest ??= new CachedManifest { HistoryStopPoint = HistoryStopPoint };
+                return s_manifest;
+            }
+        }
+
+        private readonly BillOfMaterialsProcessor _processor = new();
+        private Bom? _processedBom;
+
+        public async Task InitializeAsync()
+        {
+            await _processor.AddLibYearMetadataDataToBom(Manifest, AgentExecutablePath, SourceBomFile,
+                cancellationToken: default);
+
+            _processedBom = await LoadCycloneDxBom();
+        }
+
+        [Theory]
+        [MemberData(nameof(PropertyData))]
+        public void StoresProperty(string _, string expectedValue)
+        {
+            // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
+            Assert.Contains(_processedBom!.Metadata.Properties, property =>
+                property.Name == _ &&
+                property.Value == expectedValue
+            );
+        }
+
+        public static TheoryData<string, string> PropertyData() => new()
+        {
+            { "freshli:analysis:id", AnalysisId.ToString() },
+            { "freshli:analysis:creation-date", CreatedAt.ToString("O") },
+            { "freshli:analysis:data-point", HistoryStopPoint.AsOfDateTime.ToString("O") },
+            { "freshli:source:url", HistoryStopPoint.Repository.Url },
+            { "freshli:source:branch", HistoryStopPoint.Repository.Branch! },
+            { "freshli:source:clone-path", HistoryStopPoint.Repository.LocalPath },
+            { "freshli:commit:id", HistoryStopPoint.GitCommitId },
+            { "freshli:commit:date", HistoryStopPoint.GitCommitDateTime.ToString("O") }
+        };
+
+        private static async Task<Bom> LoadCycloneDxBom()
+        {
+            await using var sourceBomFileStream = File.OpenRead(SourceBomFile);
+            var bom = await CycloneDX.Json.Serializer.DeserializeAsync(sourceBomFileStream);
+            return bom;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivityTest.cs
@@ -61,7 +61,7 @@ public class GenerateBillOfMaterialsActivityTest
         var eventEngine = new Mock<IApplicationEventEngine>();
         eventEngine.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
 
-        cacheManager.Setup(mock => mock.StoreBomInCache("/path/to/bill-of-materials", analysisId, asOfDateTime))
+        cacheManager.Setup(mock => mock.StoreBomInCache("/path/to/bill-of-materials", analysisId, asOfDateTime, "/path/to/manifest"))
             .ReturnsAsync("/path/to/bom/in/cache");
 
         var cancellationToken = new CancellationToken(false);

--- a/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/PackagesFromBomProcessedEventTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/BillOfMaterials/PackagesFromBomProcessedEventTest.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.History;
+using Moq;
+using Xunit;
+
+namespace Corgibytes.Freshli.Cli.Test.Functionality.BillOfMaterials;
+
+public class PackagesFromBomProcessedEventTest
+{
+    private const string PathToBom = "/path/to/bom";
+    private const string AgentExecutablePath = "/path/to/agent";
+
+    private readonly Mock<IApplicationActivityEngine> _engine = new();
+    private readonly CancellationToken _cancellationToken = new();
+    private readonly PackagesFromBomProcessedEvent _applicationEvent;
+
+    public PackagesFromBomProcessedEventTest()
+    {
+        _applicationEvent = new PackagesFromBomProcessedEvent
+        {
+            Parent = _applicationEvent,
+            PathToBom = PathToBom,
+            AgentExecutablePath = AgentExecutablePath
+        };
+    }
+
+    [Fact(Timeout = Constants.DefaultTestTimeout)]
+    public async Task Handle()
+    {
+        await _applicationEvent.Handle(_engine.Object, _cancellationToken);
+
+        _engine.Verify(mock =>
+            mock.Dispatch(
+                It.Is<AddLibYearMetadataDataToBomActivity>(value =>
+                    value.Parent == _applicationEvent &&
+                    value.PathToBom == PathToBom &&
+                    value.AgentExecutablePath == AgentExecutablePath
+                ),
+                _cancellationToken,
+                ApplicationTaskMode.Tracked
+            )
+        );
+    }
+
+    [Fact(Timeout = Constants.DefaultTestTimeout)]
+    public async Task HandleFiresHistoryStopPointProcessingFailedOnException()
+    {
+        var exception = new Exception("Sample exception");
+        _engine.Setup(mock =>
+            mock.Dispatch(It.IsAny<AddLibYearMetadataDataToBomActivity>(), _cancellationToken, ApplicationTaskMode.Tracked)
+        ).Throws(exception);
+
+        await _applicationEvent.Handle(_engine.Object, _cancellationToken);
+
+        _engine.Verify(mock =>
+            mock.Dispatch(
+                It.Is<FireHistoryStopPointProcessingErrorActivity>(value =>
+                    value.Parent == _applicationEvent &&
+                    value.Error == exception
+                ),
+                _cancellationToken,
+                ApplicationTaskMode.Tracked
+            )
+        );
+    }
+}

--- a/Corgibytes.Freshli.Cli.Test/Functionality/CacheDbTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/CacheDbTest.cs
@@ -68,10 +68,18 @@ public class CacheDbTest
         await WithPreparedDatabase(async cacheDb =>
         {
             var analysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis());
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = DateTimeOffset.Now,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = analysisId,
@@ -144,10 +152,18 @@ public class CacheDbTest
     {
         await WithPreparedDatabase(async cacheDb =>
         {
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = DateTimeOffset.Now,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis()),
@@ -167,10 +183,18 @@ public class CacheDbTest
     {
         await WithPreparedDatabase(async cacheDb =>
         {
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = DateTimeOffset.Now,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis()),
@@ -198,10 +222,17 @@ public class CacheDbTest
     {
         await WithPreparedDatabase(async cacheDb =>
         {
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = DateTimeOffset.Now,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis()),
@@ -242,10 +273,18 @@ public class CacheDbTest
     {
         await WithPreparedDatabase(async cacheDb =>
         {
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = DateTimeOffset.Now,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis()),
@@ -290,10 +329,18 @@ public class CacheDbTest
             var asOfDateTime = DateTimeOffset.Now;
 
             var analysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis());
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = asOfDateTime,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = analysisId,
@@ -349,10 +396,18 @@ public class CacheDbTest
 
             var analysisId = await cacheDb.SaveAnalysis(BuildCompleteCachedAnalysis());
 
+            var repository = await cacheDb.AddCachedGitSource(new CachedGitSource()
+            {
+                Id = "repoId",
+                Url = "url",
+                Branch = "branch",
+                LocalPath = "/path/to/clone"
+            });
+
             var historyStopPoint = new CachedHistoryStopPoint
             {
                 AsOfDateTime = asOfDateTime,
-                RepositoryId = "repoId",
+                RepositoryId = repository.Id,
                 LocalPath = "localPath",
                 GitCommitId = "gitCommitId",
                 CachedAnalysisId = analysisId,

--- a/Corgibytes.Freshli.Cli.Test/Functionality/CacheDbTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/CacheDbTest.cs
@@ -15,6 +15,8 @@ namespace Corgibytes.Freshli.Cli.Test.Functionality;
 [IntegrationTest]
 public class CacheDbTest
 {
+    private TimeSpan DateTolerance { get; } = TimeSpan.FromSeconds(1);
+
     [Fact]
     public async Task RetrieveAnalysisWhenNull()
     {
@@ -39,6 +41,8 @@ public class CacheDbTest
 
             Assert.NotNull(retrievedAnalysis);
             Assert.Equal(analysisId, retrievedAnalysis.Id);
+            Assert.True(DateTimeOffset.Now - analysis.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - analysis.UpdatedAt < DateTolerance);
             Assert.Equal(analysis.RepositoryUrl, retrievedAnalysis.RepositoryUrl);
             Assert.Equal(analysis.RepositoryBranch, retrievedAnalysis.RepositoryBranch);
             Assert.Equal(analysis.UseCommitHistory, retrievedAnalysis.UseCommitHistory);
@@ -76,6 +80,8 @@ public class CacheDbTest
             var storedHistoryStopPoint = await cacheDb.AddHistoryStopPoint(historyStopPoint);
             Assert.NotNull(historyStopPoint);
             Assert.True(historyStopPoint.Id != 0);
+            Assert.True(DateTimeOffset.Now - storedHistoryStopPoint.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - storedHistoryStopPoint.UpdatedAt < DateTolerance);
             AssertCachedHistoryStopPointsEqual(historyStopPoint, storedHistoryStopPoint);
 
             var retrievedHistoryStopPoint = await cacheDb.RetrieveHistoryStopPoint(historyStopPoint.Id);
@@ -176,14 +182,14 @@ public class CacheDbTest
 
             var savedManifest = await cacheDb.AddManifest(savedHistoryStopPoint, firstManifestPath);
             Assert.True(savedManifest.Id != 0);
+            Assert.True(DateTimeOffset.Now - savedManifest.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - savedManifest.UpdatedAt < DateTolerance);
             Assert.Equal(firstManifestPath, savedManifest.ManifestFilePath);
             Assert.Equal(savedHistoryStopPoint.Id, savedManifest.HistoryStopPoint.Id);
 
             var retrievedManifest = await cacheDb.RetrieveManifest(savedHistoryStopPoint, firstManifestPath);
             Assert.NotNull(retrievedManifest);
-            Assert.Equal(savedManifest.Id, retrievedManifest.Id);
-            Assert.Equal(savedManifest.ManifestFilePath, retrievedManifest.ManifestFilePath);
-            Assert.Equal(savedHistoryStopPoint.Id, retrievedManifest.HistoryStopPoint.Id);
+            AssertManifestsEqual(savedManifest, retrievedManifest);
         });
     }
 
@@ -207,27 +213,27 @@ public class CacheDbTest
 
             var savedFirstManifest = await cacheDb.AddManifest(savedHistoryStopPoint, firstManifestPath);
             Assert.True(savedFirstManifest.Id != 0);
+            Assert.True(DateTimeOffset.Now - savedFirstManifest.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - savedFirstManifest.UpdatedAt < DateTolerance);
             Assert.Equal(firstManifestPath, savedFirstManifest.ManifestFilePath);
             Assert.Equal(savedHistoryStopPoint.Id, savedFirstManifest.HistoryStopPoint.Id);
 
             var retrievedFirstManifest = await cacheDb.RetrieveManifest(savedHistoryStopPoint, firstManifestPath);
             Assert.NotNull(retrievedFirstManifest);
-            Assert.Equal(savedFirstManifest.Id, retrievedFirstManifest.Id);
-            Assert.Equal(savedFirstManifest.ManifestFilePath, retrievedFirstManifest.ManifestFilePath);
-            Assert.Equal(savedHistoryStopPoint.Id, retrievedFirstManifest.HistoryStopPoint.Id);
+            AssertManifestsEqual(savedFirstManifest, retrievedFirstManifest);
 
             const string secondManifestPath = "/path/to/second/manifest";
 
             var savedSecondManifest = await cacheDb.AddManifest(savedHistoryStopPoint, secondManifestPath);
             Assert.True(savedSecondManifest.Id != 0);
+            Assert.True(DateTimeOffset.Now - savedSecondManifest.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - savedSecondManifest.UpdatedAt < DateTolerance);
             Assert.Equal(secondManifestPath, savedSecondManifest.ManifestFilePath);
             Assert.Equal(savedHistoryStopPoint.Id, savedSecondManifest.HistoryStopPoint.Id);
 
             var retrievedSecondManifest = await cacheDb.RetrieveManifest(savedHistoryStopPoint, secondManifestPath);
             Assert.NotNull(retrievedSecondManifest);
-            Assert.Equal(savedSecondManifest.Id, retrievedSecondManifest.Id);
-            Assert.Equal(savedSecondManifest.ManifestFilePath, retrievedSecondManifest.ManifestFilePath);
-            Assert.Equal(savedHistoryStopPoint.Id, retrievedSecondManifest.HistoryStopPoint.Id);
+            AssertManifestsEqual(savedSecondManifest, retrievedSecondManifest);
         });
     }
 
@@ -252,27 +258,27 @@ public class CacheDbTest
 
             var savedFirstManifest = await cacheDb.AddManifest(historyStopPoint, firstManifestPath);
             Assert.True(savedFirstManifest.Id != 0);
+            Assert.True(DateTimeOffset.Now - savedFirstManifest.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - savedFirstManifest.UpdatedAt < DateTolerance);
             Assert.Equal(firstManifestPath, savedFirstManifest.ManifestFilePath);
             Assert.Equal(historyStopPoint.Id, savedFirstManifest.HistoryStopPoint.Id);
 
             var retrievedFirstManifest = await cacheDb.RetrieveManifest(historyStopPoint, firstManifestPath);
             Assert.NotNull(retrievedFirstManifest);
-            Assert.Equal(savedFirstManifest.Id, retrievedFirstManifest.Id);
-            Assert.Equal(savedFirstManifest.ManifestFilePath, retrievedFirstManifest.ManifestFilePath);
-            Assert.Equal(historyStopPoint.Id, retrievedFirstManifest.HistoryStopPoint.Id);
+            AssertManifestsEqual(savedFirstManifest, retrievedFirstManifest);
 
             const string secondManifestPath = "/path/to/second/manifest";
 
             var savedSecondManifest = await cacheDb.AddManifest(historyStopPoint, secondManifestPath);
             Assert.True(savedSecondManifest.Id != 0);
+            Assert.True(DateTimeOffset.Now - savedSecondManifest.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - savedSecondManifest.UpdatedAt < DateTolerance);
             Assert.Equal(secondManifestPath, savedSecondManifest.ManifestFilePath);
             Assert.Equal(historyStopPoint.Id, savedSecondManifest.HistoryStopPoint.Id);
 
             var retrievedSecondManifest = await cacheDb.RetrieveManifest(historyStopPoint, secondManifestPath);
             Assert.NotNull(retrievedSecondManifest);
-            Assert.Equal(savedSecondManifest.Id, retrievedSecondManifest.Id);
-            Assert.Equal(savedSecondManifest.ManifestFilePath, retrievedSecondManifest.ManifestFilePath);
-            Assert.Equal(historyStopPoint.Id, retrievedSecondManifest.HistoryStopPoint.Id);
+            AssertManifestsEqual(savedSecondManifest, retrievedSecondManifest);
         });
     }
 
@@ -311,6 +317,8 @@ public class CacheDbTest
 
             var storedPackageLibYear = await cacheDb.AddPackageLibYear(storedManifest, cachedPackageLibYear);
             Assert.True(storedHistoryStopPoint.Id != 0);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.UpdatedAt < DateTolerance);
             cachedPackageLibYear.Id = storedPackageLibYear.Id;
             AssertCachedPackageLibYearsEqual(cachedPackageLibYear, storedPackageLibYear);
 
@@ -367,12 +375,16 @@ public class CacheDbTest
 
             var storedPackageLibYear = await cacheDb.AddPackageLibYear(firstManifest, cachedPackageLibYear);
             Assert.True(storedPackageLibYear.Id != 0);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.UpdatedAt < DateTolerance);
             cachedPackageLibYear.Id = storedPackageLibYear.Id;
             AssertCachedPackageLibYearsEqual(cachedPackageLibYear, storedPackageLibYear);
             Assert.Single(storedPackageLibYear.Manifests);
 
             storedPackageLibYear = await cacheDb.AddPackageLibYear(secondManifest, cachedPackageLibYear);
             Assert.True(storedPackageLibYear.Id != 0);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.CreatedAt < DateTolerance);
+            Assert.True(DateTimeOffset.Now - storedPackageLibYear.UpdatedAt < DateTolerance);
             cachedPackageLibYear.Id = storedPackageLibYear.Id;
             AssertCachedPackageLibYearsEqual(cachedPackageLibYear, storedPackageLibYear);
             Assert.Equal(2, storedPackageLibYear.Manifests.Count);
@@ -393,6 +405,8 @@ public class CacheDbTest
                 retrievedPackageLibYear.Id,
                 updatedFirstManifest.PackageLibYears.First().Id
             );
+            Assert.True(DateTimeOffset.Now - updatedFirstManifest.UpdatedAt < DateTolerance);
+
 
             var updatedSecondManifest =
                 await cacheDb.RetrieveManifest(storedHistoryStopPoint, "/path/to/second/manifest");
@@ -401,6 +415,8 @@ public class CacheDbTest
                 retrievedPackageLibYear.Id,
                 updatedSecondManifest.PackageLibYears.First().Id
             );
+            Assert.True(DateTimeOffset.Now - updatedSecondManifest.UpdatedAt < DateTolerance);
+
         });
     }
 
@@ -449,6 +465,8 @@ public class CacheDbTest
                         && expectedPackage.PackageUrlWithoutVersion == actualPackage.PackageUrlWithoutVersion
                         && expectedPackage.Version == actualPackage.Version
                         && expectedPackage.ReleasedAt == actualPackage.ReleasedAt
+                        && DateTimeOffset.Now - actualPackage.CreatedAt < DateTolerance
+                        && DateTimeOffset.Now - actualPackage.UpdatedAt < DateTolerance
                     )
                 );
             }
@@ -486,9 +504,20 @@ public class CacheDbTest
             ApiAnalysisId = Guid.NewGuid()
         };
 
+    private static void AssertManifestsEqual(CachedManifest expected, CachedManifest actual)
+    {
+        Assert.Equal(expected.Id, actual.Id);
+        Assert.Equal(expected.CreatedAt, actual.CreatedAt);
+        Assert.Equal(expected.UpdatedAt, actual.UpdatedAt);
+        Assert.Equal(expected.ManifestFilePath, actual.ManifestFilePath);
+        Assert.Equal(expected.HistoryStopPoint.Id, actual.HistoryStopPoint.Id);
+    }
+
     private static void AssertCachedHistoryStopPointsEqual(CachedHistoryStopPoint expected, CachedHistoryStopPoint actual)
     {
         Assert.Equal(expected.Id, actual.Id);
+        Assert.Equal(expected.CreatedAt, actual.CreatedAt);
+        Assert.Equal(expected.UpdatedAt, actual.UpdatedAt);
         Assert.Equal(expected.AsOfDateTime, actual.AsOfDateTime);
         Assert.Equal(expected.RepositoryId, actual.RepositoryId);
         Assert.Equal(expected.LocalPath, actual.LocalPath);

--- a/Corgibytes.Freshli.Cli.Test/Functionality/Git/ComputeHistoryTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/Git/ComputeHistoryTest.cs
@@ -43,12 +43,16 @@ public class ComputeHistoryTest : FreshliTest
         var expectedStops = new List<HistoryIntervalStop>
         {
             new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                 new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero)),
             new("ef14791d014431952aa721fa2a9b22afb8d4f144",
+                new DateTimeOffset(2021, 1, 13, 00, 00, 00, TimeSpan.Zero),
                 new DateTimeOffset(2021, 1, 13, 00, 00, 00, TimeSpan.Zero)),
             new("ca6c6f099e0bb1a63bf5aba7e3db90ba0cff4546",
+                new DateTimeOffset(2021, 1, 12, 00, 00, 00, TimeSpan.Zero),
                 new DateTimeOffset(2021, 1, 12, 00, 00, 00, TimeSpan.Zero)),
             new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                 new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero))
         };
 
@@ -65,6 +69,7 @@ public class ComputeHistoryTest : FreshliTest
         var expectedStops = new List<HistoryIntervalStop>
         {
             new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                 new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero))
         };
 
@@ -120,15 +125,19 @@ public class ComputeHistoryTest : FreshliTest
                 {
                     // Friday week 4
                     new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                        new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 31, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 4 (start of range)
                     new("ef14791d014431952aa721fa2a9b22afb8d4f144",
+                        new DateTimeOffset(2021, 1, 13, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 25, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 2
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 11, 00, 00, 00, TimeSpan.Zero)),
                     // Thursday week 53
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero))
                 }
             }
@@ -152,17 +161,23 @@ public class ComputeHistoryTest : FreshliTest
                 {
                     // Start date
                     new("ca6c6f099e0bb1a63bf5aba7e3db90ba0cff4546",
+                        new DateTimeOffset(2021, 1, 4, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 5, 00, 00, 00, TimeSpan.Zero)),
                     new("ca6c6f099e0bb1a63bf5aba7e3db90ba0cff4546",
+                        new DateTimeOffset(2021, 1, 4, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 4, 00, 00, 00, TimeSpan.Zero)),
                     new("ef14791d014431952aa721fa2a9b22afb8d4f144",
+                        new DateTimeOffset(2021, 1, 3, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 3, 00, 00, 00, TimeSpan.Zero)),
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 2, 00, 00, 00, TimeSpan.Zero)),
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 1, 00, 00, 00, TimeSpan.Zero)),
                     // End date
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero))
                 }
             }
@@ -178,21 +193,27 @@ public class ComputeHistoryTest : FreshliTest
                 {
                     // Friday week 4
                     new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                        new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 31, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 4
                     new("ef14791d014431952aa721fa2a9b22afb8d4f144",
+                        new DateTimeOffset(2021, 1, 13, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 25, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 3
                     new("ef14791d014431952aa721fa2a9b22afb8d4f144",
+                        new DateTimeOffset(2021, 1, 13, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 18, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 2
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 11, 00, 00, 00, TimeSpan.Zero)),
                     // Monday week 1
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 4, 00, 00, 00, TimeSpan.Zero)),
                     // Thursday week 53
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero))
                 }
             }
@@ -208,12 +229,15 @@ public class ComputeHistoryTest : FreshliTest
                 {
                     // Start date
                     new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                        new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 31, 00, 00, 00, TimeSpan.Zero)),
                     // First day of first month
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 1, 00, 00, 00, TimeSpan.Zero)),
                     // End date
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2020, 12, 31, 00, 00, 00, TimeSpan.Zero))
                 }
             }
@@ -237,13 +261,17 @@ public class ComputeHistoryTest : FreshliTest
                 {
                     // Start date
                     new("edd01470c5fb4c5922db060f59bf0e0a5ddce6a5",
+                        new DateTimeOffset(2021, 1, 29, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 31, 00, 00, 00, TimeSpan.Zero)),
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2019, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2021, 1, 1, 00, 00, 00, TimeSpan.Zero)),
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2019, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2020, 1, 1, 00, 00, 00, TimeSpan.Zero)),
                     // End date
                     new("4f6b7990ad45b2c5bf5817c359de72729654dd9f",
+                        new DateTimeOffset(2019, 12, 31, 00, 00, 00, TimeSpan.Zero),
                         new DateTimeOffset(2019, 12, 31, 00, 00, 00, TimeSpan.Zero))
                 }
             }

--- a/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/History/ComputeHistoryActivityTest.cs
@@ -67,10 +67,12 @@ public class ComputeHistoryActivityTest
         {
             new(
                 "75c7fcc7336ee718050c4a5c8dfb5598622787b2",
+                DateTime.Parse("2020-01-10T02:21:24+00:00"),
                 new DateTimeOffset(2021, 2, 20, 12, 31, 34, TimeSpan.Zero)
             ),
             new(
                 "583d813db3e28b9b44a29db352e2f0e1b4c6e420",
+                DateTime.Parse("2020-04-18T05:14:14+00:00"),
                 new DateTimeOffset(2021, 5, 19, 15, 24, 24, TimeSpan.Zero)
             )
         };
@@ -100,6 +102,7 @@ public class ComputeHistoryActivityTest
         {
             new(
                 "75c7fcc7336ee718050c4a5c8dfb5598622787b2",
+                DateTimeOffset.Parse("2020-01-10T02:21:24+00:00"),
                 new DateTimeOffset(2021, 2, 20, 12, 31, 34, TimeSpan.Zero)
             )
         };
@@ -129,6 +132,7 @@ public class ComputeHistoryActivityTest
         {
             new(
                 "75c7fcc7336ee718050c4a5c8dfb5598622787b2",
+                DateTime.Parse("2020-01-10T02:21:24+00:00"),
                 new DateTimeOffset(2021, 2, 20, 12, 31, 34, TimeSpan.Zero)
             )
         };
@@ -211,10 +215,12 @@ public class ComputeHistoryActivityTest
             {
                 Id = stopPointId,
                 GitCommitId = stopPoint.GitCommitIdentifier,
+                GitCommitDateTime = stopPoint.GitCommitDateTime,
                 AsOfDateTime = stopPoint.AsOfDateTime
             };
             _cacheDb.Setup(mock => mock.AddHistoryStopPoint(It.Is<CachedHistoryStopPoint>(value =>
                     value.GitCommitId == stopPoint.GitCommitIdentifier &&
+                    value.GitCommitDateTime == stopPoint.GitCommitDateTime &&
                     value.AsOfDateTime == stopPoint.AsOfDateTime)))
                 .ReturnsAsync(historyStopPoint);
             stopPointId++;
@@ -239,6 +245,7 @@ public class ComputeHistoryActivityTest
                     value.RepositoryId == HistoryStopData.RepositoryId &&
                     value.LocalPath == path &&
                     value.GitCommitId == stopPoint.GitCommitIdentifier &&
+                    value.GitCommitDateTime == stopPoint.GitCommitDateTime &&
                     value.AsOfDateTime == stopPoint.AsOfDateTime
                 )));
 

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
@@ -8,10 +8,8 @@ using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Functionality.History;
 using Corgibytes.Freshli.Cli.Functionality.LibYear;
-using CycloneDX.Models;
 using Moq;
 using PackageUrl;
-using SQLitePCL;
 using Xunit;
 
 namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;

--- a/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
+++ b/Corgibytes.Freshli.Cli.Test/Functionality/LibYear/DeterminePackagesFromBomActivityTest.cs
@@ -4,11 +4,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality;
+using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Functionality.History;
 using Corgibytes.Freshli.Cli.Functionality.LibYear;
+using CycloneDX.Models;
 using Moq;
 using PackageUrl;
+using SQLitePCL;
 using Xunit;
 
 namespace Corgibytes.Freshli.Cli.Test.Functionality.LibYear;
@@ -61,6 +64,8 @@ public class DeterminePackagesFromBomActivityTest
         _eventClient.Setup(mock => mock.ServiceProvider).Returns(serviceProvider.Object);
         serviceProvider.Setup(mock => mock.GetService(typeof(IBomReader))).Returns(bomReader.Object);
 
+        _eventClient.Setup(mock => mock.Wait(_activity, _cancellationToken)).Returns(ValueTask.CompletedTask);
+
         await _activity.Handle(_eventClient.Object, _cancellationToken);
 
         _eventClient.Verify(mock =>
@@ -84,6 +89,21 @@ public class DeterminePackagesFromBomActivityTest
                 ),
                 _cancellationToken,
                 ApplicationTaskMode.Tracked
+            )
+        );
+
+        Assert.NotNull(_activity.WaitingForChildrenThread);
+        _activity.StopWaitingForChildren();
+
+        _eventClient.Verify(mock =>
+            mock.Fire(
+                It.Is<PackagesFromBomProcessedEvent>(value =>
+                    value.Parent == _activity &&
+                    value.PathToBom == _activity.PathToBom &&
+                    value.AgentExecutablePath == _activity.AgentExecutablePath
+                ),
+                _cancellationToken,
+                ApplicationTaskMode.Untracked
             )
         );
     }

--- a/Corgibytes.Freshli.Cli/DataModel/CachedAnalysis.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedAnalysis.cs
@@ -10,7 +10,7 @@ namespace Corgibytes.Freshli.Cli.DataModel;
 
 [Index(nameof(Id), IsUnique = true)]
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-public class CachedAnalysis
+public class CachedAnalysis : TimeStampedEntity
 {
     // ReSharper disable once PropertyCanBeMadeInitOnly.Global
     [Required] public Guid Id { get; set; }

--- a/Corgibytes.Freshli.Cli/DataModel/CachedGitSource.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedGitSource.cs
@@ -13,6 +13,8 @@ public class CachedGitSource : TimeStampedEntity
 {
     [Required] public string Id { get; set; } = null!;
     [Required] public string Url { get; set; } = null!;
+    // TODO: Make this field required. It should be set to the name of the default branch instead of null.
     public string? Branch { get; set; }
+    // TODO: Add validation to ensure that this is not a relative path.
     [Required] public string LocalPath { get; set; } = null!;
 }

--- a/Corgibytes.Freshli.Cli/DataModel/CachedGitSource.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedGitSource.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Corgibytes.Freshli.Cli.DataModel;
 
 [Index(nameof(Id), IsUnique = true)]
-public class CachedGitSource
+public class CachedGitSource : TimeStampedEntity
 {
     [Required] public string Id { get; set; } = null!;
     [Required] public string Url { get; set; } = null!;

--- a/Corgibytes.Freshli.Cli/DataModel/CachedHistoryStopPoint.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedHistoryStopPoint.cs
@@ -23,11 +23,14 @@ public class CachedHistoryStopPoint : TimeStampedEntity
 
     // ReSharper disable once PropertyCanBeMadeInitOnly.Global
     [Required] public string GitCommitId { get; set; } = null!;
+    [Required] public DateTimeOffset GitCommitDateTime { get; set; }
 
     [Required] public Guid CachedAnalysisId { get; set; }
 
     // ReSharper disable once UnusedMember.Global
     public virtual CachedAnalysis CachedAnalysis { get; set; } = null!;
+
+    public virtual CachedGitSource Repository { get; set; } = null!;
 
     public virtual List<CachedManifest> Manifests { get; } = new();
 }

--- a/Corgibytes.Freshli.Cli/DataModel/CachedHistoryStopPoint.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedHistoryStopPoint.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Cli.DataModel;
 
 [Index(nameof(Id), IsUnique = true)]
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-public class CachedHistoryStopPoint
+public class CachedHistoryStopPoint : TimeStampedEntity
 {
     [Required] public int Id { get; set; }
 

--- a/Corgibytes.Freshli.Cli/DataModel/CachedManifest.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedManifest.cs
@@ -6,7 +6,7 @@ namespace Corgibytes.Freshli.Cli.DataModel;
 
 [Index(nameof(Id), IsUnique = true)]
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-public class CachedManifest
+public class CachedManifest : TimeStampedEntity
 {
     [Required] public int Id { get; set; }
 

--- a/Corgibytes.Freshli.Cli/DataModel/CachedPackage.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedPackage.cs
@@ -10,7 +10,7 @@ namespace Corgibytes.Freshli.Cli.DataModel;
 [Index(nameof(Id), IsUnique = true)]
 [Index(nameof(PackageUrlWithoutVersion))]
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-public class CachedPackage
+public class CachedPackage : TimeStampedEntity
 {
     public CachedPackage()
     {

--- a/Corgibytes.Freshli.Cli/DataModel/CachedPackageLibYear.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedPackageLibYear.cs
@@ -10,7 +10,7 @@ namespace Corgibytes.Freshli.Cli.DataModel;
 [Index(nameof(Id), IsUnique = true)]
 [Index(nameof(PackageUrl), nameof(AsOfDateTime), IsUnique = true)]
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global
-public class CachedPackageLibYear
+public class CachedPackageLibYear : TimeStampedEntity
 {
     [Required] public int Id { get; set; }
 

--- a/Corgibytes.Freshli.Cli/DataModel/CachedProperty.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/CachedProperty.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Corgibytes.Freshli.Cli.DataModel;
 
 [Index(nameof(Key), IsUnique = true)]
-public class CachedProperty
+public class CachedProperty : TimeStampedEntity
 {
     [Required] public int Id { get; set; }
 

--- a/Corgibytes.Freshli.Cli/DataModel/TimeStampedEntity.cs
+++ b/Corgibytes.Freshli.Cli/DataModel/TimeStampedEntity.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Corgibytes.Freshli.Cli.DataModel;
+
+public abstract class TimeStampedEntity
+{
+    public DateTimeOffset? CreatedAt { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/HistoryStopData.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/HistoryStopData.cs
@@ -7,7 +7,10 @@ public class HistoryStopData : IHistoryStopData
     public required IConfiguration Configuration { get; init; }
     public string? LocalDirectory { get; init; }
     public required string RepositoryId { get; init; }
+    // TODO: The commit id should still be set, even if we're analyzing a local directory
     public string? CommitId { get; init; }
+    // TODO: The commit date should still be set, even if we're analyzing a local directory
+    public DateTimeOffset? CommittedAt { get; init; }
     public DateTimeOffset AsOfDateTime { get; init; }
 
     public string Path

--- a/Corgibytes.Freshli.Cli/Functionality/Analysis/IHistoryStopData.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Analysis/IHistoryStopData.cs
@@ -8,6 +8,7 @@ public interface IHistoryStopData
 {
     public string RepositoryId { get; }
     public string? CommitId { get; }
+    public DateTimeOffset? CommittedAt { get; }
     public string Path { get; }
     public DateTimeOffset AsOfDateTime { get; }
 }

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivity.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.History;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+public class AddLibYearMetadataDataToBomActivity : IApplicationActivity, IHistoryStopPointProcessingTask
+{
+    public required IHistoryStopPointProcessingTask? Parent { get; init; }
+    public required string PathToBom { get; init; }
+    public required string AgentExecutablePath { get; init; }
+
+    public async ValueTask Handle(IApplicationEventEngine eventClient, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var bomProcessor = eventClient.ServiceProvider.GetRequiredService<IBillOfMaterialsProcessor>();
+            await bomProcessor.AddLibYearMetadataDataToBom(AgentExecutablePath, PathToBom, cancellationToken);
+
+            await eventClient.Fire(
+                new LibYearMetadataAddedToBomEvent
+                {
+                    Parent = this,
+                    PathToBom = PathToBom,
+                    AgentExecutablePath = AgentExecutablePath
+                },
+                cancellationToken
+            );
+        }
+        catch (Exception error)
+        {
+            await eventClient.Fire(new HistoryStopPointProcessingFailedEvent(this, error), cancellationToken);
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/AddLibYearMetadataDataToBomActivity.cs
@@ -17,8 +17,11 @@ public class AddLibYearMetadataDataToBomActivity : IApplicationActivity, IHistor
     {
         try
         {
+            var manifest = Parent?.Manifest;
+            _ = manifest ?? throw new Exception("Parent's Manifest is null");
+
             var bomProcessor = eventClient.ServiceProvider.GetRequiredService<IBillOfMaterialsProcessor>();
-            await bomProcessor.AddLibYearMetadataDataToBom(AgentExecutablePath, PathToBom, cancellationToken);
+            await bomProcessor.AddLibYearMetadataDataToBom(manifest, AgentExecutablePath, PathToBom, cancellationToken);
 
             await eventClient.Fire(
                 new LibYearMetadataAddedToBomEvent

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/BillOfMaterialsProcessor.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/BillOfMaterialsProcessor.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.DataModel;
+using CycloneDX.Models;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+public class BillOfMaterialsProcessor : IBillOfMaterialsProcessor
+{
+    public async Task AddLibYearMetadataDataToBom(CachedManifest manifest, string agentExecutablePath, string pathToBom,
+        CancellationToken cancellationToken)
+    {
+        await using var bomReadStream = File.OpenRead(pathToBom);
+        var bom = await CycloneDX.Json.Serializer.DeserializeAsync(bomReadStream);
+        bomReadStream.Close();
+
+        if (bom == null)
+        {
+            throw new Exception("Unable to open bom");
+        }
+
+        bom.AddMetadataProperties(new List<Property>()
+        {
+            new()
+            {
+                Name = "freshli:analysis:id",
+                Value = manifest.HistoryStopPoint.CachedAnalysis.Id.ToString()
+            },
+            new()
+            {
+                Name = "freshli:analysis:creation-date",
+                Value = manifest.HistoryStopPoint.CachedAnalysis.CreatedAt!.Value.ToString("O")
+            },
+            new()
+            {
+                Name = "freshli:analysis:data-point",
+                Value = manifest.HistoryStopPoint.AsOfDateTime.ToString("O")
+            },
+            new()
+            {
+                Name = "freshli:source:url",
+                Value = manifest.HistoryStopPoint.Repository.Url
+            },
+            new()
+            {
+                Name = "freshli:source:branch",
+                Value = manifest.HistoryStopPoint.Repository.Branch!
+            },
+            new()
+            {
+                Name = "freshli:source:clone-path",
+                Value = manifest.HistoryStopPoint.Repository.LocalPath
+            },
+            new()
+            {
+                Name = "freshli:commit:id",
+                Value = manifest.HistoryStopPoint.GitCommitId
+            },
+            new()
+            {
+                Name = "freshli:commit:date",
+                Value = manifest.HistoryStopPoint.GitCommitDateTime.ToString("O")
+            }
+        });
+
+        await using var bomWriteStream = File.Open(pathToBom, FileMode.Truncate);
+        await CycloneDX.Json.Serializer.SerializeAsync(bom, bomWriteStream);
+        await bomWriteStream.FlushAsync(cancellationToken);
+        bomWriteStream.Close();
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/BomExtensions.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/BomExtensions.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using CycloneDX.Models;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+internal static class BomExtensions
+{
+    public static void AddMetadataProperties(this Bom bom, List<Property> properties)
+    {
+        bom.Metadata ??= new Metadata();
+        bom.Metadata.Properties ??= new List<Property>();
+
+        bom.Metadata.Properties.AddRange(properties);
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/GenerateBillOfMaterialsActivity.cs
@@ -72,7 +72,7 @@ public class GenerateBillOfMaterialsActivity : IApplicationActivity, ISynchroniz
                 return;
             }
 
-            var cachedBomFilePath = await cacheManager.StoreBomInCache(bomFilePath, historyStopPoint.CachedAnalysis.Id, asOfDateTime);
+            var cachedBomFilePath = await cacheManager.StoreBomInCache(bomFilePath, historyStopPoint.CachedAnalysis.Id, asOfDateTime, fullManifestPath);
 
             await eventClient.Fire(
                 new BillOfMaterialsGeneratedEvent

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
@@ -8,6 +8,7 @@ public interface IBillOfMaterialsProcessor
 {
     public Task AddLibYearMetadataDataToBom(
         CachedManifest manifest,
+        // ReSharper disable once UnusedParameter.Global
         string agentExecutablePath,
         string pathToBom,
         CancellationToken cancellationToken);

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+public interface IBillOfMaterialsProcessor
+{
+    public Task AddLibYearMetadataDataToBom(string agentExecutablePath, string pathToBom,
+        CancellationToken cancellationToken);
+}

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/IBillOfMaterialsProcessor.cs
@@ -1,10 +1,14 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.DataModel;
 
 namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 
 public interface IBillOfMaterialsProcessor
 {
-    public Task AddLibYearMetadataDataToBom(string agentExecutablePath, string pathToBom,
+    public Task AddLibYearMetadataDataToBom(
+        CachedManifest manifest,
+        string agentExecutablePath,
+        string pathToBom,
         CancellationToken cancellationToken);
 }

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/LibYearMetadataAddedToBomEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/LibYearMetadataAddedToBomEvent.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.History;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+public class LibYearMetadataAddedToBomEvent : IApplicationEvent, IHistoryStopPointProcessingTask
+{
+    public required IHistoryStopPointProcessingTask? Parent { get; init; }
+    public required string PathToBom { get; init; }
+    public required string AgentExecutablePath { get; init; }
+
+    public ValueTask Handle(IApplicationActivityEngine eventClient, CancellationToken cancellationToken)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/PackagesFromBomProcessedEvent.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/BillOfMaterials/PackagesFromBomProcessedEvent.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Corgibytes.Freshli.Cli.Functionality.Engine;
+using Corgibytes.Freshli.Cli.Functionality.History;
+
+namespace Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
+
+public class PackagesFromBomProcessedEvent : IApplicationEvent, IHistoryStopPointProcessingTask
+{
+    public required IHistoryStopPointProcessingTask? Parent { get; init; }
+    public required string PathToBom { get; init; }
+    public required string AgentExecutablePath { get; init; }
+
+    public async ValueTask Handle(IApplicationActivityEngine eventClient, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await eventClient.Dispatch(
+                new AddLibYearMetadataDataToBomActivity
+                {
+                    Parent = this,
+                    PathToBom = PathToBom,
+                    AgentExecutablePath = AgentExecutablePath
+                },
+                cancellationToken
+            );
+        }
+        catch (Exception error)
+        {
+            await eventClient.Dispatch(
+                new FireHistoryStopPointProcessingErrorActivity(this, error),
+                cancellationToken
+            );
+        }
+    }
+}

--- a/Corgibytes.Freshli.Cli/Functionality/CacheDb.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/CacheDb.cs
@@ -14,6 +14,7 @@ using Polly.Retry;
 
 namespace Corgibytes.Freshli.Cli.Functionality;
 
+// TODO: This class should handle validating that the data is correct before saving it.
 public class CacheDb : ICacheDb, IDisposable, IAsyncDisposable
 {
     private readonly AsyncLock _cacheDbLock = new();
@@ -83,12 +84,13 @@ public class CacheDb : ICacheDb, IDisposable, IAsyncDisposable
         }
     }
 
-    public async ValueTask AddCachedGitSource(CachedGitSource cachedGitSource)
+    public async ValueTask<CachedGitSource> AddCachedGitSource(CachedGitSource cachedGitSource)
     {
         using (await _cacheDbLock.LockAsync())
         {
-            await _context.CachedGitSources.AddAsync(cachedGitSource);
+            var savedEntity = await _context.CachedGitSources.AddAsync(cachedGitSource);
             await SaveChanges(_context);
+            return savedEntity.Entity;
         }
     }
 

--- a/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Resources;
@@ -97,8 +98,7 @@ public class CacheManager : ICacheManager, IDisposable, IAsyncDisposable
 
     private static string GetFilePathHash(string filePath)
     {
-        var sha256 = SHA256.Create();
-        var sourceManifestHash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(filePath));
+        var sourceManifestHash = SHA256.HashData(Encoding.UTF8.GetBytes(filePath));
         return BitConverter.ToString(sourceManifestHash).Replace("-", string.Empty);
     }
 

--- a/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/CacheManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Resources;
@@ -94,12 +95,20 @@ public class CacheManager : ICacheManager, IDisposable, IAsyncDisposable
         return focus;
     }
 
-    public async ValueTask<string> StoreBomInCache(string bomFilePath, Guid analysisId, DateTimeOffset asOfDateTime)
+    private static string GetFilePathHash(string filePath)
     {
-        var bomFileInfo = new FileInfo(bomFilePath);
+        var sha256 = SHA256.Create();
+        var sourceManifestHash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(filePath));
+        return BitConverter.ToString(sourceManifestHash).Replace("-", string.Empty);
+    }
+
+    public async ValueTask<string> StoreBomInCache(string bomFilePath, Guid analysisId, DateTimeOffset asOfDateTime, string sourceManifestFilePath)
+    {
+        var sourceManifestFilePathHash = GetFilePathHash(sourceManifestFilePath);
+        var targetFileName = $"{sourceManifestFilePathHash}-bom.json";
 
         var bomCacheDirInfo = await GetDirectoryInCache("boms", analysisId.ToString(), asOfDateTime.UtcDateTime.ToString("yyyyMMddTHHmmssZ"));
-        var cachedBomFilePath = Path.Combine(bomCacheDirInfo.FullName, bomFileInfo.Name);
+        var cachedBomFilePath = Path.Combine(bomCacheDirInfo.FullName, targetFileName);
 
         // use Task.Run to wait for file IO to complete
         await Task.Run(() => File.Copy(bomFilePath, cachedBomFilePath, true));

--- a/Corgibytes.Freshli.Cli/Functionality/Git/ComputeHistory.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/ComputeHistory.cs
@@ -86,21 +86,22 @@ public class ComputeHistory : IComputeHistory
         return (
                 from offset in range
                 let lastCommitForOffset = gitCommits.First(commit => commit.CommittedAt <= offset)
-                select new HistoryIntervalStop(lastCommitForOffset.ShaIdentifier, offset))
+                select new HistoryIntervalStop(lastCommitForOffset.ShaIdentifier, lastCommitForOffset.CommittedAt, offset))
             .ToList();
     }
 
+    // BUG: This should also include the same stops as ComputeWithHistoryInterval in addition to all of the commit dates.
     public IEnumerable<HistoryIntervalStop> ComputeCommitHistory(IHistoryStopData historyStopData)
     {
         var commitHistory = _listCommits.ForRepository(historyStopData);
         return commitHistory
-            .Select(gitCommit => new HistoryIntervalStop(gitCommit.ShaIdentifier, gitCommit.CommittedAt)).ToList();
+            .Select(gitCommit => new HistoryIntervalStop(gitCommit.ShaIdentifier, gitCommit.CommittedAt, gitCommit.CommittedAt)).ToList();
     }
 
     public IEnumerable<HistoryIntervalStop> ComputeLatestOnly(IHistoryStopData historyStopData)
     {
         var gitCommit = _listCommits.MostRecentCommit(historyStopData);
-        return new List<HistoryIntervalStop> { new(gitCommit.ShaIdentifier, gitCommit.CommittedAt) };
+        return new List<HistoryIntervalStop> { new(gitCommit.ShaIdentifier, gitCommit.CommittedAt, gitCommit.CommittedAt) };
     }
 
     private static DateTimeOffset DetermineRangeStartDate(DateTimeOffset startAtDate, string? quantifier)

--- a/Corgibytes.Freshli.Cli/Functionality/Git/HistoryIntervalStop.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/HistoryIntervalStop.cs
@@ -7,4 +7,4 @@ using System;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Git;
 
-public record HistoryIntervalStop(string GitCommitIdentifier, DateTimeOffset AsOfDateTime);
+public record HistoryIntervalStop(string GitCommitIdentifier, DateTimeOffset GitCommitDateTime, DateTimeOffset AsOfDateTime);

--- a/Corgibytes.Freshli.Cli/Functionality/Git/VerifyGitRepositoryInLocalDirectoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Git/VerifyGitRepositoryInLocalDirectoryActivity.cs
@@ -57,8 +57,11 @@ public class VerifyGitRepositoryInLocalDirectoryActivity : IApplicationActivity
             var cachedGitSource = new CachedGitSource
             {
                 Id = cachedGitSourceId.Id,
+                // TODO: This needs to retrieve the default git remote if `analysis.RepositoryUrl` is a local directory.
                 Url = analysis.RepositoryUrl,
+                // TODO: This needs to retrieve the current branch name (or commit sha if detached head).
                 Branch = null,
+                // TODO: Need to ensure that this is a full expanded path.
                 LocalPath = analysis.RepositoryUrl
             };
             await gitSourceRepository.Save(cachedGitSource);

--- a/Corgibytes.Freshli.Cli/Functionality/History/ComputeHistoryActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/History/ComputeHistoryActivity.cs
@@ -88,7 +88,8 @@ public class ComputeHistoryActivity : IApplicationActivity
                 Configuration = configuration,
                 RepositoryId = HistoryStopData.RepositoryId,
                 CommitId = historyIntervalStop.GitCommitIdentifier,
-                AsOfDateTime = historyIntervalStop.AsOfDateTime
+                AsOfDateTime = historyIntervalStop.AsOfDateTime,
+                CommittedAt = historyIntervalStop.GitCommitDateTime
             };
 
             var historyStopPoint = await cacheDb.AddHistoryStopPoint(
@@ -98,6 +99,7 @@ public class ComputeHistoryActivity : IApplicationActivity
                     RepositoryId = historyStop.RepositoryId,
                     LocalPath = historyStop.Path,
                     GitCommitId = historyStop.CommitId,
+                    GitCommitDateTime = historyStop.CommittedAt!.Value,
                     AsOfDateTime = historyStop.AsOfDateTime
                 });
 

--- a/Corgibytes.Freshli.Cli/Functionality/ICacheDb.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/ICacheDb.cs
@@ -17,7 +17,7 @@ public interface ICacheDb
     public ValueTask<CachedManifest?> RetrieveManifest(CachedHistoryStopPoint historyStopPoint, string manifestFilePath);
     public ValueTask<CachedPackageLibYear> AddPackageLibYear(CachedManifest manifest, CachedPackageLibYear packageLibYear);
     public ValueTask<CachedGitSource?> RetrieveCachedGitSource(CachedGitSourceId id);
-    public ValueTask AddCachedGitSource(CachedGitSource cachedGitSource);
+    public ValueTask<CachedGitSource> AddCachedGitSource(CachedGitSource cachedGitSource);
     public ValueTask RemoveCachedGitSource(CachedGitSource cachedGitSource);
     public ValueTask<CachedHistoryStopPoint?> RetrieveHistoryStopPoint(int historyStopPointId);
     public ValueTask<CachedPackageLibYear?> RetrievePackageLibYear(PackageURL packageUrl, DateTimeOffset asOfDateTime);

--- a/Corgibytes.Freshli.Cli/Functionality/ICacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/ICacheManager.cs
@@ -10,7 +10,7 @@ public interface ICacheManager
     public ValueTask<bool> Destroy();
     public ValueTask<DirectoryInfo> GetDirectoryInCache(params string[] directoryStructure);
     public ValueTask<bool> Prepare();
-    public ValueTask<string> StoreBomInCache(string pathToBom, Guid analysisId, DateTimeOffset asOfDateTime);
+    public ValueTask<string> StoreBomInCache(string pathToBom, Guid analysisId, DateTimeOffset asOfDateTime, string pathToManifest);
 
     public ValueTask<ICacheDb> GetCacheDb();
 }

--- a/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
+++ b/Corgibytes.Freshli.Cli/IoC/FreshliServiceBuilder.cs
@@ -7,6 +7,7 @@ using Corgibytes.Freshli.Cli.Commands;
 using Corgibytes.Freshli.Cli.Formatters;
 using Corgibytes.Freshli.Cli.Functionality;
 using Corgibytes.Freshli.Cli.Functionality.Analysis;
+using Corgibytes.Freshli.Cli.Functionality.BillOfMaterials;
 using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Functionality.FreshliWeb;
 using Corgibytes.Freshli.Cli.Functionality.Git;
@@ -42,6 +43,7 @@ public class FreshliServiceBuilder
         Services.AddScoped<IRunner, Runner>();
         Services.AddSingleton<HttpClient>();
         Services.AddSingleton<IFileValidator, FileValidator>();
+        Services.AddSingleton<IBillOfMaterialsProcessor, BillOfMaterialsProcessor>();
         RegisterBaseCommand();
         RegisterAnalyzeCommand();
         RegisterFailCommand();

--- a/Corgibytes.Freshli.Cli/Migrations/20230925212603_TimeStampedEntities.Designer.cs
+++ b/Corgibytes.Freshli.Cli/Migrations/20230925212603_TimeStampedEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Corgibytes.Freshli.Cli.DataModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Corgibytes.Freshli.Cli.Migrations
 {
     [DbContext(typeof(CacheContext))]
-    partial class CacheContextModelSnapshot : ModelSnapshot
+    [Migration("20230925212603_TimeStampedEntities")]
+    partial class TimeStampedEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Corgibytes.Freshli.Cli/Migrations/20230925212603_TimeStampedEntities.cs
+++ b/Corgibytes.Freshli.Cli/Migrations/20230925212603_TimeStampedEntities.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Corgibytes.Freshli.Cli.Migrations;
+
+/// <inheritdoc />
+public partial class TimeStampedEntities : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedProperties",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedProperties",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedPackages",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedPackages",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedPackageLibYears",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedPackageLibYears",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedManifests",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedManifests",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedHistoryStopPoints",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedHistoryStopPoints",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedGitSources",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedGitSources",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "CreatedAt",
+            table: "CachedAnalyses",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "UpdatedAt",
+            table: "CachedAnalyses",
+            type: "TEXT",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedProperties");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedProperties");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedPackages");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedPackages");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedPackageLibYears");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedPackageLibYears");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedManifests");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedManifests");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedHistoryStopPoints");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedHistoryStopPoints");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedGitSources");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedGitSources");
+
+        migrationBuilder.DropColumn(
+            name: "CreatedAt",
+            table: "CachedAnalyses");
+
+        migrationBuilder.DropColumn(
+            name: "UpdatedAt",
+            table: "CachedAnalyses");
+    }
+}

--- a/Corgibytes.Freshli.Cli/Migrations/20230926133341_AddDateTimeToCachedHistoryStopPoint.Designer.cs
+++ b/Corgibytes.Freshli.Cli/Migrations/20230926133341_AddDateTimeToCachedHistoryStopPoint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Corgibytes.Freshli.Cli.DataModel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Corgibytes.Freshli.Cli.Migrations
 {
     [DbContext(typeof(CacheContext))]
-    partial class CacheContextModelSnapshot : ModelSnapshot
+    [Migration("20230926133341_AddDateTimeToCachedHistoryStopPoint")]
+    partial class AddDateTimeToCachedHistoryStopPoint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Corgibytes.Freshli.Cli/Migrations/20230926133341_AddDateTimeToCachedHistoryStopPoint.cs
+++ b/Corgibytes.Freshli.Cli/Migrations/20230926133341_AddDateTimeToCachedHistoryStopPoint.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Corgibytes.Freshli.Cli.Migrations;
+
+/// <inheritdoc />
+public partial class AddDateTimeToCachedHistoryStopPoint : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<DateTimeOffset>(
+            name: "GitCommitDateTime",
+            table: "CachedHistoryStopPoints",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CachedHistoryStopPoints_RepositoryId",
+            table: "CachedHistoryStopPoints",
+            column: "RepositoryId");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_CachedHistoryStopPoints_CachedGitSources_RepositoryId",
+            table: "CachedHistoryStopPoints",
+            column: "RepositoryId",
+            principalTable: "CachedGitSources",
+            principalColumn: "Id",
+            onDelete: ReferentialAction.Cascade);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_CachedHistoryStopPoints_CachedGitSources_RepositoryId",
+            table: "CachedHistoryStopPoints");
+
+        migrationBuilder.DropIndex(
+            name: "IX_CachedHistoryStopPoints_RepositoryId",
+            table: "CachedHistoryStopPoints");
+
+        migrationBuilder.DropColumn(
+            name: "GitCommitDateTime",
+            table: "CachedHistoryStopPoints");
+    }
+}


### PR DESCRIPTION
* Stores analysis metadata in each CycloneDX BOM that is generated
* Ensures that a new CycloneDX BOM is generated for each manifest that is analyzed (this was technically a bug that was discovered during this implementation)

Addresses the following issues:
* Fixes #541.