### PR TITLE
Switches to default Linux GitHub Actions worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest-8-cores]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
This is going to increase the time it takes to run CI, but it's going to reduce costs a little bit.