### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -17,7 +17,7 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="">
       <Link>LICENSE</Link>
     </None>
-    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.3" />
     <PackageReference Include="CliWrap" Version="3.6.4" />
     <PackageReference Include="Corgibytes.Freshli.Lib" Version="0.5.0" />
     <PackageReference Include="CycloneDX.Core" Version="6.0.0" />

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -17,6 +17,7 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="">
       <Link>LICENSE</Link>
     </None>
+    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
     <PackageReference Include="CliWrap" Version="3.6.4" />
     <PackageReference Include="Corgibytes.Freshli.Lib" Version="0.5.0" />
     <PackageReference Include="CycloneDX.Core" Version="6.0.0" />
@@ -30,7 +31,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="NamedServices.Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
     <PackageReference Include="NLog" Version="5.2.4" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
     <PackageReference Include="NLog.Extensions.Hosting" Version="5.3.4" />

--- a/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
+++ b/Corgibytes.Freshli.Cli/Corgibytes.Freshli.Cli.csproj
@@ -17,7 +17,7 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="">
       <Link>LICENSE</Link>
     </None>
-    <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
     <PackageReference Include="CliWrap" Version="3.6.4" />
     <PackageReference Include="Corgibytes.Freshli.Lib" Version="0.5.0" />
     <PackageReference Include="CycloneDX.Core" Version="6.0.0" />

--- a/Corgibytes.Freshli.Cli/Functionality/Cache/CacheDb.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Cache/CacheDb.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AsyncKeyedLock;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality.Extensions;
 using Corgibytes.Freshli.Cli.Functionality.Git;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using NeoSmart.AsyncLock;
 using PackageUrl;
 using Polly;
 using Polly.Retry;
@@ -17,7 +17,7 @@ namespace Corgibytes.Freshli.Cli.Functionality.Cache;
 // TODO: This class should handle validating that the data is correct before saving it.
 public class CacheDb : ICacheDb, IDisposable, IAsyncDisposable
 {
-    private readonly AsyncLock _cacheDbLock = new();
+    private readonly AsyncNonKeyedLocker _cacheDbLock = new();
 
     private readonly AsyncRetryPolicy _sqliteRetryPolicy = Policy
         .Handle<SqliteException>()

--- a/Corgibytes.Freshli.Cli/Functionality/Cache/CacheManager.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/Cache/CacheManager.cs
@@ -5,20 +5,20 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using AsyncKeyedLock;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality.Api.Auth;
 using Corgibytes.Freshli.Cli.Functionality.Support;
 using Corgibytes.Freshli.Cli.Resources;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using NeoSmart.AsyncLock;
 
 namespace Corgibytes.Freshli.Cli.Functionality.Cache;
 
 public class CacheManager : ICacheManager, IDisposable, IAsyncDisposable
 {
     private readonly IConfiguration _configuration;
-    private readonly AsyncLock _cacheDbLock = new();
+    private readonly AsyncNonKeyedLocker _cacheDbLock = new();
     private CacheDb? _cacheDb;
 
     public CacheManager(IConfiguration configuration) => _configuration = configuration;

--- a/Corgibytes.Freshli.Cli/Functionality/LibYear/ComputeLibYearForPackageActivity.cs
+++ b/Corgibytes.Freshli.Cli/Functionality/LibYear/ComputeLibYearForPackageActivity.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using AsyncKeyedLock;
 using Corgibytes.Freshli.Cli.DataModel;
 using Corgibytes.Freshli.Cli.Functionality.Agents;
 using Corgibytes.Freshli.Cli.Functionality.Cache;
@@ -8,7 +9,6 @@ using Corgibytes.Freshli.Cli.Functionality.Engine;
 using Corgibytes.Freshli.Cli.Functionality.History;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NeoSmart.AsyncLock;
 using PackageUrl;
 
 namespace Corgibytes.Freshli.Cli.Functionality.LibYear;
@@ -18,7 +18,7 @@ public class ComputeLibYearForPackageActivity : IApplicationActivity, IHistorySt
     public required IHistoryStopPointProcessingTask? Parent { get; init; }
     public required PackageURL Package { get; init; }
     public required string AgentExecutablePath { get; init; }
-    private static readonly AsyncLock s_cacheLibYearLock = new();
+    private static readonly AsyncNonKeyedLocker s_cacheLibYearLock = new();
 
     public int Priority
     {


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144